### PR TITLE
tar i bruk eksternId for å hente status fra oppdrag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/VentePåStatusFraØkonomiTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/VentePåStatusFraØkonomiTask.kt
@@ -35,7 +35,7 @@ class VentePåStatusFraØkonomiTask(
         val oppdragId = OppdragId(
                 fagsystem = iverksett.fagsak.stønadstype.tilKlassifisering(),
                 personIdent = iverksett.søker.personIdent,
-                behandlingsId = iverksett.behandling.behandlingId.toString()
+                behandlingsId = iverksett.behandling.eksternId.toString()
         )
 
         val oppdragstatus = oppdragClient.hentStatus(oppdragId)


### PR DESCRIPTION
familie-oppdrag feiler å hente ut oppdrag pga feil oppdragId som bruker behandlingId i stedet for eksternId