### PR TITLE
Kaller integrasjoner for å hente alle identer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <prosessering.version>1.20210302133042_76527ed</prosessering.version>
         <changelist>-SNAPSHOT</changelist>
         <start-class>no.nav.familie.ef.iverksett.WebApplicationKt</start-class>
-        <felles-kontrakter.version>2.0_20210601181057_6846c15</felles-kontrakter.version>
+        <felles-kontrakter.version>2.0_20210602212816_2e16190</felles-kontrakter.version>
         <familie.kontrakter.stonadsstatistikk-ef>2.0_20210520150847_3c00370</familie.kontrakter.stonadsstatistikk-ef>
         <token-validation-spring.version>1.3.5</token-validation-spring.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <prosessering.version>1.20210302133042_76527ed</prosessering.version>
         <changelist>-SNAPSHOT</changelist>
         <start-class>no.nav.familie.ef.iverksett.WebApplicationKt</start-class>
-        <felles-kontrakter.version>2.0_20210602212816_2e16190</felles-kontrakter.version>
+        <felles-kontrakter.version>2.0_20210601181057_6846c15</felles-kontrakter.version>
         <familie.kontrakter.stonadsstatistikk-ef>2.0_20210520150847_3c00370</familie.kontrakter.stonadsstatistikk-ef>
         <token-validation-spring.version>1.3.5</token-validation-spring.version>
     </properties>

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/felles/FamilieIntegrasjonerClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/felles/FamilieIntegrasjonerClient.kt
@@ -1,0 +1,40 @@
+package no.nav.familie.ef.iverksett.felles
+
+import no.nav.familie.http.client.AbstractRestClient
+import no.nav.familie.kontrakter.felles.PersonIdent
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.getDataOrThrow
+import no.nav.familie.kontrakter.felles.personopplysning.FinnPersonidenterResponse
+import no.nav.familie.kontrakter.felles.personopplysning.PersonIdentMedHistorikk
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestOperations
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URI
+
+@Component
+class FamilieIntegrasjonerClient(
+        @Qualifier("azure") restOperations: RestOperations,
+        @Value("\${FAMILIE_INTEGRASJONER_API_URL}")
+        private val integrasjonUri: URI
+) : AbstractRestClient(restOperations, "familie.integrasjoner") {
+
+    val logger = LoggerFactory.getLogger(this::class.java)
+
+    private val hentIdenterURI =
+            UriComponentsBuilder.fromUri(integrasjonUri).pathSegment(PATH_HENT_IDENTER).build().toUri()
+
+    fun hentIdenter(personident: String, medHistprikk: Boolean): List<PersonIdentMedHistorikk> {
+        val uri = UriComponentsBuilder.fromUri(hentIdenterURI).queryParam("historikk", medHistprikk).build().toUri()
+        val response = postForEntity<Ressurs<FinnPersonidenterResponse>>(uri, PersonIdent(personident))
+        return response.getDataOrThrow().identer
+    }
+
+    companion object {
+
+        const val PATH_HENT_IDENTER = "personopplysning/v1/identer/ENF"
+    }
+
+}

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infotrygd/SendFattetVedtakTilInfotrygdTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infotrygd/SendFattetVedtakTilInfotrygdTask.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.iverksett.infotrygd
 
+import no.nav.familie.ef.iverksett.felles.FamilieIntegrasjonerClient
 import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
 import no.nav.familie.kontrakter.ef.infotrygd.OpprettVedtakHendelseDto
 import no.nav.familie.prosessering.AsyncTaskStep
@@ -16,6 +17,7 @@ import java.util.UUID
         beskrivelse = "Sender hendelse om fattet vedtak til infotrygd"
 )
 class SendFattetVedtakTilInfotrygdTask(private val infotrygdFeedClient: InfotrygdFeedClient,
+                                       private val familieIntegrasjonerClient: FamilieIntegrasjonerClient,
                                        private val iverksettingRepository: IverksettingRepository,
                                        private val taskRepository: TaskRepository) : AsyncTaskStep {
 
@@ -24,7 +26,8 @@ class SendFattetVedtakTilInfotrygdTask(private val infotrygdFeedClient: Infotryg
         val iverksett = iverksettingRepository.hent(behandlingId)
 
         val stønadstype = iverksett.fagsak.stønadstype
-        val personIdenter = iverksett.søker.allePersonIdenter
+        val personIdenter = familieIntegrasjonerClient.hentIdenter(iverksett.søker.personIdent, true)
+                .map { it.personIdent }.toSet()
         val startDato = iverksett.vedtak.tilkjentYtelse.andelerTilkjentYtelse.minOfOrNull { it.periodebeløp.fraOgMed }
                         ?: error("Finner ikke noen andel med fraOgMed for behandling=$behandlingId")
 

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/transformer/IverksettDtoToDomain.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/transformer/IverksettDtoToDomain.kt
@@ -47,8 +47,7 @@ fun SøkerDto.toDomain(): Søker {
                  personIdent = this.personIdent,
                  barn = this.barn.map { it.toDomain() },
                  tilhørendeEnhet = this.tilhørendeEnhet,
-                 kode6eller7 = this.kode6eller7,
-                 allePersonIdenter = this.allePersonIdenter.toSet())
+                 kode6eller7 = this.kode6eller7)
 }
 
 fun BehandlingsdetaljerDto.toDomain(): Behandlingsdetaljer {

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/domene/Iverksett.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/domene/Iverksett.kt
@@ -33,8 +33,7 @@ data class Søker(
         val personIdent: String,
         val barn: List<Barn> = ArrayList(),
         val tilhørendeEnhet: String,
-        val kode6eller7: Boolean,
-        val allePersonIdenter: Set<String> = emptySet()
+        val kode6eller7: Boolean
 )
 
 data class Vedtaksdetaljer(

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/infotrygd/SendFattetVedtakTilInfotrygdTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/infotrygd/SendFattetVedtakTilInfotrygdTaskTest.kt
@@ -5,6 +5,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
+import no.nav.familie.ef.iverksett.felles.FamilieIntegrasjonerClient
 import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
 import no.nav.familie.ef.iverksett.iverksetting.domene.AndelTilkjentYtelse
 import no.nav.familie.ef.iverksett.iverksetting.domene.Iverksett
@@ -13,6 +14,7 @@ import no.nav.familie.ef.iverksett.util.opprettIverksett
 import no.nav.familie.kontrakter.ef.felles.StønadType
 import no.nav.familie.kontrakter.ef.infotrygd.OpprettVedtakHendelseDto
 import no.nav.familie.kontrakter.ef.iverksett.Periodetype
+import no.nav.familie.kontrakter.felles.personopplysning.PersonIdentMedHistorikk
 import no.nav.familie.prosessering.domene.Task
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -22,33 +24,40 @@ import java.util.UUID
 internal class SendFattetVedtakTilInfotrygdTaskTest {
 
     private val infotrygdFeedClient = mockk<InfotrygdFeedClient>(relaxed = true)
+    private val familieIntegrasjonerClient = mockk<FamilieIntegrasjonerClient>(relaxed = true)
     private val iverksettingRepository = mockk<IverksettingRepository>()
 
-    private val task = SendFattetVedtakTilInfotrygdTask(infotrygdFeedClient, iverksettingRepository, mockk())
+    private val task =
+            SendFattetVedtakTilInfotrygdTask(infotrygdFeedClient, familieIntegrasjonerClient, iverksettingRepository, mockk())
 
     private val behandlingId = UUID.randomUUID()
-    private val personIdenter = setOf("2")
+    private val iverksett = opprettIverksett(behandlingId)
+    private val personIdent = iverksett.søker.personIdent
+    private val historiskPersonIdent = "2"
     private val perioder = listOf(
             Pair(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 1, 31)),
             Pair(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 31)),
             Pair(LocalDate.of(2022, 1, 1), LocalDate.of(2022, 1, 31))
     )
 
+    private val identer = listOf(PersonIdentMedHistorikk(personIdent, false),
+                                 PersonIdentMedHistorikk(historiskPersonIdent, true))
+
     @Test
     internal fun `skal sende fattet vedtak til infotrygd med første perioden i andelene`() {
         val hendelseSlot = slot<OpprettVedtakHendelseDto>()
         every { iverksettingRepository.hent(behandlingId) } returns opprettIverksettMedTilkjentYtelse()
         every { infotrygdFeedClient.opprettVedtakHendelse(capture(hendelseSlot)) } just runs
+        every { familieIntegrasjonerClient.hentIdenter(any(), any()) } returns identer
 
         task.doTask(Task(SendFattetVedtakTilInfotrygdTask.TYPE, behandlingId.toString()))
 
-        assertThat(hendelseSlot.captured.personIdenter).isEqualTo(personIdenter)
+        assertThat(hendelseSlot.captured.personIdenter).containsExactlyInAnyOrder(personIdent, historiskPersonIdent)
         assertThat(hendelseSlot.captured.type).isEqualTo(StønadType.OVERGANGSSTØNAD)
         assertThat(hendelseSlot.captured.startdato).isEqualTo(LocalDate.of(2020, 1, 1))
     }
 
     private fun opprettIverksettMedTilkjentYtelse(): Iverksett {
-        val iverksett = opprettIverksett(behandlingId)
         val vedtak = iverksett.vedtak
         val tilkjentYtelse = vedtak.tilkjentYtelse
         val andelerTilkjentYtelse = perioder.map {
@@ -56,7 +65,6 @@ internal class SendFattetVedtakTilInfotrygdTaskTest {
         }
 
         val nyTilkjentYtelse = tilkjentYtelse.copy(andelerTilkjentYtelse = andelerTilkjentYtelse)
-        return iverksett.copy(vedtak = vedtak.copy(tilkjentYtelse = nyTilkjentYtelse),
-                              søker = iverksett.søker.copy(allePersonIdenter = personIdenter))
+        return iverksett.copy(vedtak = vedtak.copy(tilkjentYtelse = nyTilkjentYtelse))
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/util/IverksettMockUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/util/IverksettMockUtil.kt
@@ -142,8 +142,7 @@ fun opprettIverksett(behandlingId: UUID): Iverksett {
                     personIdent = "12345678910",
                     barn = emptyList(),
                     tilhørendeEnhet = "4489",
-                    kode6eller7 = false,
-                    allePersonIdenter = setOf("12345678910")
+                    kode6eller7 = false
             ),
             vedtak = Vedtaksdetaljer(
                     vedtaksresultat = Vedtaksresultat.INNVILGET,


### PR DESCRIPTION
Requestene mot infotrygd er vel noe som skal slettes på sikt, sånn att ha alle identer i Iverksett-dto'en er egentlige litt unødvendig. Av den grunnen så får denne kalle på integrasjoner for å hente alleIdenter i stedet. 