### PR TITLE
Skal kjøre publiseringstaskene i en egen flyt etter at ef-sak har fer…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/arena/SendFattetVedtakTilArenaTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/arena/SendFattetVedtakTilArenaTask.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ef.iverksett.arena
 
 import no.nav.familie.ef.iverksett.felles.FamilieIntegrasjonerClient
-import no.nav.familie.ef.iverksett.infrastruktur.task.opprettNesteTask
+import no.nav.familie.ef.iverksett.infrastruktur.task.opprettNestePubliseringTask
 import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
 import no.nav.familie.ef.sak.featuretoggle.FeatureToggleService
 import no.nav.familie.prosessering.AsyncTaskStep
@@ -34,7 +34,7 @@ class SendFattetVedtakTilArenaTask(private val vedtakhendelseProducer: Vedtakhen
     }
 
     override fun onCompletion(task: Task) {
-        taskRepository.save(task.opprettNesteTask())
+        taskRepository.save(task.opprettNestePubliseringTask())
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/DistribuerVedtaksbrevTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/DistribuerVedtaksbrevTask.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ef.iverksett.brev
 
-import no.nav.familie.ef.iverksett.infrastruktur.task.opprettNesteTask
 import no.nav.familie.ef.iverksett.iverksetting.domene.DistribuerVedtaksbrevResultat
 import no.nav.familie.ef.iverksett.iverksetting.tilstand.TilstandRepository
 import no.nav.familie.prosessering.AsyncTaskStep
@@ -19,9 +18,7 @@ import java.util.UUID
                      triggerTidVedFeilISekunder = 15 * 60L,
                      beskrivelse = "Distribuerer vedtaksbrev.")
 class DistribuerVedtaksbrevTask(private val journalpostClient: JournalpostClient,
-                                private val tilstandRepository: TilstandRepository,
-                                private val taskRepository: TaskRepository
-) : AsyncTaskStep {
+                                private val tilstandRepository: TilstandRepository) : AsyncTaskStep {
 
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
@@ -33,10 +30,6 @@ class DistribuerVedtaksbrevTask(private val journalpostClient: JournalpostClient
                                                                  DistribuerVedtaksbrevResultat(bestillingId = bestillingId)
         )
         logger.info("Distribuer vedtaksbrev journalpost=[${journalpostId}] for behandling=[${behandlingId}] med bestillingId=[$bestillingId]")
-    }
-
-    override fun onCompletion(task: Task) {
-        taskRepository.save(task.opprettNesteTask())
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infotrygd/SendFattetVedtakTilInfotrygdTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infotrygd/SendFattetVedtakTilInfotrygdTask.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ef.iverksett.infotrygd
 
 import no.nav.familie.ef.iverksett.felles.FamilieIntegrasjonerClient
-import no.nav.familie.ef.iverksett.infrastruktur.task.opprettNesteTask
+import no.nav.familie.ef.iverksett.infrastruktur.task.opprettNestePubliseringTask
 import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
 import no.nav.familie.kontrakter.ef.infotrygd.OpprettVedtakHendelseDto
 import no.nav.familie.prosessering.AsyncTaskStep
@@ -36,7 +36,7 @@ class SendFattetVedtakTilInfotrygdTask(private val infotrygdFeedClient: Infotryg
     }
 
     override fun onCompletion(task: Task) {
-        taskRepository.save(task.opprettNesteTask())
+        taskRepository.save(task.opprettNestePubliseringTask())
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infotrygd/SendPerioderTilInfotrygdTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infotrygd/SendPerioderTilInfotrygdTask.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ef.iverksett.infotrygd
 
 import no.nav.familie.ef.iverksett.felles.FamilieIntegrasjonerClient
-import no.nav.familie.ef.iverksett.infrastruktur.task.opprettNesteTask
+import no.nav.familie.ef.iverksett.infrastruktur.task.opprettNestePubliseringTask
 import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
 import no.nav.familie.kontrakter.ef.infotrygd.OpprettPeriodeHendelseDto
 import no.nav.familie.kontrakter.ef.infotrygd.Periode
@@ -38,7 +38,7 @@ class SendPerioderTilInfotrygdTask(private val infotrygdFeedClient: InfotrygdFee
     }
 
     override fun onCompletion(task: Task) {
-        taskRepository.save(task.opprettNesteTask())
+        taskRepository.save(task.opprettNestePubliseringTask())
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskFlyt.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskFlyt.kt
@@ -48,7 +48,8 @@ private fun Task.lagTask(nesteTask: TaskType): Task {
     return if (nesteTask.triggerTidAntallMinutterFrem != null) {
         Task(type = nesteTask.type,
              payload = this.payload,
-             triggerTid = LocalDateTime.now().plusMinutes(nesteTask.triggerTidAntallMinutterFrem))
+             properties = this.metadata).copy(triggerTid = LocalDateTime.now().plusMinutes(nesteTask.triggerTidAntallMinutterFrem))
+
     } else {
         Task(type = nesteTask.type,
              payload = this.payload,

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskFlyt.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskFlyt.kt
@@ -21,6 +21,9 @@ fun hovedflyt() = listOf(
         TaskType(VentePåStatusFraØkonomiTask.TYPE, 3),
         TaskType(JournalførVedtaksbrevTask.TYPE),
         TaskType(DistribuerVedtaksbrevTask.TYPE),
+)
+
+fun publiseringsflyt() = listOf(
         TaskType(SendFattetVedtakTilInfotrygdTask.TYPE),
         TaskType(SendPerioderTilInfotrygdTask.TYPE),
         TaskType(SendFattetVedtakTilArenaTask.TYPE),
@@ -28,11 +31,20 @@ fun hovedflyt() = listOf(
 )
 
 fun TaskType.nesteHovedflytTask() = hovedflyt().zipWithNext().first { this.type == it.first.type }.second
+fun TaskType.nestePubliseringsflytTask() = publiseringsflyt().zipWithNext().first { this.type == it.first.type }.second
 
 
 fun Task.opprettNesteTask(): Task {
     val nesteTask = TaskType(this.type).nesteHovedflytTask()
+    return lagTask(nesteTask)
+}
 
+fun Task.opprettNestePubliseringTask(): Task {
+    val nesteTask = TaskType(this.type).nestePubliseringsflytTask()
+    return lagTask(nesteTask)
+}
+
+private fun Task.lagTask(nesteTask: TaskType): Task {
     return if (nesteTask.triggerTidAntallMinutterFrem != null) {
         Task(type = nesteTask.type,
              payload = this.payload,
@@ -42,5 +54,4 @@ fun Task.opprettNesteTask(): Task {
              payload = this.payload,
              properties = this.metadata)
     }
-
 }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/IverksettingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/IverksettingController.kt
@@ -42,6 +42,12 @@ class IverksettingController(
         return status?.let { ResponseEntity(status, HttpStatus.OK) } ?: ResponseEntity(null, HttpStatus.NOT_FOUND)
     }
 
+    @PostMapping("/vedtakshendelse/{behandlingId}")
+    fun publiserVedtakshendelser(@PathVariable behandlingId: UUID): ResponseEntity<Any> {
+        iverksettingService.publiserVedtak(behandlingId)
+        return ResponseEntity.ok().build()
+    }
+
     private fun opprettBrev(iverksettDto: IverksettDto, fil: MultipartFile): Brev {
         return Brev(iverksettDto.behandling.behandlingId, fil.bytes)
     }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/IverksettingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/IverksettingService.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.iverksett.iverksetting
 
+import no.nav.familie.ef.iverksett.infotrygd.SendFattetVedtakTilInfotrygdTask
 import no.nav.familie.ef.iverksett.iverksetting.domene.Brev
 import no.nav.familie.ef.iverksett.iverksetting.domene.Iverksett
 import no.nav.familie.ef.iverksett.iverksetting.domene.OppdragResultat
@@ -44,6 +45,20 @@ class IverksettingService(val taskRepository: TaskRepository,
                                        })
 
         taskRepository.save(førsteHovedflytTask)
+    }
+
+    @Transactional
+    fun publiserVedtak(behandlingId: UUID) {
+        val iverksett = iverksettingRepository.hent(behandlingId)
+        taskRepository.save(Task(
+                type = SendFattetVedtakTilInfotrygdTask.TYPE,
+                payload = behandlingId.toString(),
+                properties = Properties().apply {
+                    this["personIdent"] = iverksett.søker.personIdent
+                    this["behandlingId"] = behandlingId.toString()
+                    this["saksbehandler"] = iverksett.vedtak.saksbehandlerId
+                }
+        ))
     }
 
     fun utledStatus(behandlingId: UUID): IverksettStatus? {

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brev/DistribuerVedtaksbrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brev/DistribuerVedtaksbrevTaskTest.kt
@@ -18,7 +18,7 @@ internal class DistribuerVedtaksbrevTaskTest {
 
     val journalpostClient = mockk<JournalpostClient>()
     val tilstandRepository = mockk<TilstandRepository>()
-    val distribuerVedtaksbrevTask = DistribuerVedtaksbrevTask(journalpostClient, tilstandRepository, mockk(relaxed = true))
+    val distribuerVedtaksbrevTask = DistribuerVedtaksbrevTask(journalpostClient, tilstandRepository)
 
     @Test
     internal fun `skal distribuere brev`() {
@@ -42,4 +42,5 @@ internal class DistribuerVedtaksbrevTaskTest {
         assertThat(distribuerVedtaksbrevResultat.captured.bestillingId).isEqualTo(bestillingId)
         assertThat(distribuerVedtaksbrevResultat.captured.dato).isNotNull()
     }
+
 }


### PR DESCRIPTION
…digstilt behandlingen fra sin side.

For å unngå race condition for eksterne (særlig Arena, men samme vil skje med BAKS) konsumenter må vi ferdigstille behandlingen i `ef-sak` før vi publiserer vedtakene våre. 