### PR TITLE
Trenger ikke stacktrace i prosessering når status fra oppdrag ikke er OK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <revision>1.0</revision>
         <dotenv.version>6.2.1</dotenv.version>
         <logback.spring.starter>2.7.1</logback.spring.starter>
-        <prosessering.version>1.20210617141104_8f0760d</prosessering.version>
+        <prosessering.version>1.20210621084119_fd91328</prosessering.version>
         <changelist>-SNAPSHOT</changelist>
         <start-class>no.nav.familie.ef.iverksett.WebApplicationKt</start-class>
         <felles-kontrakter.version>2.0_20210615094025_b6f9ecc</felles-kontrakter.version>

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/IverksettingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/IverksettingService.kt
@@ -14,6 +14,7 @@ import no.nav.familie.kontrakter.felles.oppdrag.OppdragId
 import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
+import no.nav.familie.prosessering.error.TaskExceptionUtenStackTrace
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.Properties
@@ -99,13 +100,14 @@ class IverksettingService(val taskRepository: TaskRepository,
         )
 
         val oppdragstatus = oppdragClient.hentStatus(oppdragId)
+
+        if (oppdragstatus != OppdragStatus.KVITTERT_OK) {
+            throw TaskExceptionUtenStackTrace("Status fra oppdrag er ikke ok, status=$oppdragstatus")
+        }
+
         tilstandRepository.oppdaterOppdragResultat(
                 behandlingId = behandlingId,
                 OppdragResultat(oppdragStatus = oppdragstatus)
         )
-        when (oppdragstatus) {
-            OppdragStatus.KVITTERT_OK -> return
-            else -> error("Status fra oppdrag er ikke ok, status : ${oppdragstatus}")
-        }
     }
 }


### PR DESCRIPTION
https://github.com/navikt/familie-prosessering-backend/pull/169/files
https://github.com/navikt/familie-prosessering/pull/93/files