### PR TITLE
Skal bruke et annet alias for mq i prod

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,7 +93,7 @@ arena-mq:
    channel: P_FAMILIE_EF_IVERKS
    hostname: a01apvl247.adeo.no
    port: 1414
-   queueName: QA.P_475.SOB_VEDTAKHENDELSER_ARE
+   queueName: QA.P475.SOB_VEDTAKHENDELSER_ARE
    servicebruker: ${SERVICEBRUKER}
    servicebrukerPassord: ${SERVICEBRUKER_PASSORD}
 


### PR DESCRIPTION
Fra Akhtar:
```
Jeg har gitt dere tilgang til QA.P475.SOB_VEDTAKHENDELSER_ARE
11:07
PS. begge aliasene peker på samme base/local kø
Alias kø                                                                Base kø
QA.P475.SOB_VEDTAKHENDELSER_ARE     P475.SOB_VEDTAKHENDELSER_ARE
QA.P_475.SOB_VEDTAKHENDELSER_ARE    P475.SOB_VEDTAKHENDELSER_ARE
```

Han kunde fikse att fi får tilgang til nr 2 der, men det er mest riktig å endre denne til å ikke bruke underscore for P475