### PR TITLE
Legger til kafkaconfig for å overskreve default loggingproducerlistener

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/behandlingsstatistikk/BehandlingsstatistikkProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/behandlingsstatistikk/BehandlingsstatistikkProducer.kt
@@ -1,16 +1,14 @@
 package no.nav.familie.ef.iverksett.behandlingsstatistikk
 
+import no.nav.familie.ef.iverksett.infrastruktur.service.KafkaProducerService
 import no.nav.familie.eksterne.kontrakter.saksstatistikk.ef.BehandlingDVH
 import no.nav.familie.kontrakter.felles.objectMapper
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Service
 
 @Service
-class BehandlingsstatistikkProducer(
-        private val kafkaTemplate: KafkaTemplate<String, String>
-) {
+class BehandlingsstatistikkProducer(private val kafkaProducerService: KafkaProducerService) {
 
     @Value("\${ENSLIG_FORSORGER_BEHANDLING_TOPIC}")
     lateinit var topic: String
@@ -22,7 +20,7 @@ class BehandlingsstatistikkProducer(
         logger.info("Sending to Kafka topic: {}", topic)
         secureLogger.debug("Sending to Kafka topic: {}\nBehandlingstatistikk: {}", topic, behandlingDvh)
         runCatching {
-            kafkaTemplate.send(topic, behandlingDvh.toJson()).get()
+            kafkaProducerService.send(topic, behandlingDvh.toJson())
             logger.info("Behandlingstatistikk sent to Kafka")
             secureLogger.info("$behandlingDvh sent to Kafka.")
         }.onFailure {

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/configuration/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/configuration/KafkaConfig.kt
@@ -1,0 +1,25 @@
+package no.nav.familie.ef.iverksett.infrastruktur.configuration
+
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.LoggingProducerListener
+
+
+@Configuration
+class KafkaConfig {
+
+    @Bean
+    fun kafkaTemplate(properties: KafkaProperties): KafkaTemplate<String, String> {
+        val producerListener = LoggingProducerListener<String, String>()
+        producerListener.setIncludeContents(false)
+        val producerFactory = DefaultKafkaProducerFactory<String, String>(properties.buildProducerProperties())
+
+        return KafkaTemplate(producerFactory).apply<KafkaTemplate<String, String>> {
+            setProducerListener(producerListener)
+        }
+    }
+
+}

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/configuration/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/configuration/KafkaConfig.kt
@@ -7,7 +7,6 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.support.LoggingProducerListener
 
-
 @Configuration
 class KafkaConfig {
 

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/service/KafkaProducerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/service/KafkaProducerService.kt
@@ -1,0 +1,12 @@
+package no.nav.familie.ef.iverksett.infrastruktur.service
+
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class KafkaProducerService(private val kafkaTemplate: KafkaTemplate<String, String>) {
+
+    fun send(topic: String, payload: String) {
+        kafkaTemplate.send(topic, payload).get()
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkKafkaProducer.kt
@@ -1,16 +1,15 @@
 package no.nav.familie.ef.iverksett.vedtakstatistikk
 
+import no.nav.familie.ef.iverksett.infrastruktur.service.KafkaProducerService
 import no.nav.familie.eksterne.kontrakter.ef.BehandlingDVH
 import no.nav.familie.kontrakter.felles.objectMapper
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Service
 
 @Service
-class VedtakstatistikkKafkaProducer(
-    private val kafkaTemplate: KafkaTemplate<String, String>
-) {
+class VedtakstatistikkKafkaProducer(private val kafkaProducerService: KafkaProducerService) {
+
     @Value("\${ENSLIG_FORSORGER_VEDTAK_TOPIC}")
     lateinit var topic: String
 
@@ -21,7 +20,7 @@ class VedtakstatistikkKafkaProducer(
         logger.info("Sending to Kafka topic: {}", topic)
         secureLogger.debug("Sending to Kafka topic: {}\nVedtakStatistikk: {}", topic, vedtakStatistikk)
         runCatching {
-            kafkaTemplate.send(topic, vedtakStatistikk.toJson()).get()
+            kafkaProducerService.send(topic, vedtakStatistikk.toJson())
             logger.info("Vedtakstatistikk sent to Kafka")
             secureLogger.info("$vedtakStatistikk sent to Kafka.")
         }.onFailure {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,8 @@ spring:
                type: PKCS12
                location: ${KAFKA_TRUSTSTORE_PATH}
                password: ${KAFKA_CREDSTORE_PASSWORD}
+      producer:
+         acks: all
 logging:
    config: "classpath:logback-spring.xml"
 

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/behandlingsstatistikk/BehandlingsstatistikkControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/behandlingsstatistikk/BehandlingsstatistikkControllerTest.kt
@@ -1,7 +1,5 @@
 package no.nav.familie.ef.iverksett.behandlingsstatistikk
 
-import io.mockk.every
-import io.mockk.mockk
 import no.nav.familie.ef.iverksett.ServerTest
 import no.nav.familie.ef.iverksett.util.opprettBehandlingsstatistikkDto
 import no.nav.familie.kontrakter.ef.iverksett.Hendelse
@@ -13,9 +11,6 @@ import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.kafka.core.KafkaTemplate
-import org.springframework.kafka.support.SendResult
-import org.springframework.util.concurrent.ListenableFuture
 import java.util.UUID
 
 class BehandlingsstatistikkControllerTest : ServerTest() {

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/config/KafkaTemplateMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/config/KafkaTemplateMock.kt
@@ -1,15 +1,12 @@
 package no.nav.familie.ef.iverksett.config
 
-import io.mockk.Runs
-import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
+import no.nav.familie.ef.iverksett.infrastruktur.service.KafkaProducerService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
-import org.springframework.kafka.core.KafkaTemplate
-import org.springframework.kafka.support.SendResult
-import org.springframework.util.concurrent.ListenableFuture
 
 @Configuration
 @Profile("mock-kafkatemplate")
@@ -17,12 +14,9 @@ class KafkaTemplateMock {
 
     @Bean
     @Primary
-    fun kafkaTemplate(): KafkaTemplate<String, String> {
-        val kafkaTemplate = mockk<KafkaTemplate<String, String>>(relaxed = true)
-        val listenableFuture = mockk<ListenableFuture<SendResult<String, String>>>()
-        val sendResult = mockk<SendResult<String, String>>()
-        every { kafkaTemplate.send(any(), any()) } returns listenableFuture
-        every { listenableFuture.get() } returns sendResult
-        return kafkaTemplate
+    fun kafkaProducerService(): KafkaProducerService {
+        val kafkaProducer = mockk<KafkaProducerService>(relaxed = true)
+        justRun { kafkaProducer.send(any(), any()) }
+        return kafkaProducer
     }
 }

--- a/src/test/resources/application-servertest.yml
+++ b/src/test/resources/application-servertest.yml
@@ -9,6 +9,9 @@ no.nav.security.jwt:
     cookie_name: localhost-idtoken
     proxy_url: #Default satt, skal være null i integrasjonstest
 
+funksjonsbrytere:
+  enabled: false
+
 arena-mq:
   queueManager: queuemanager
   channel: channel


### PR DESCRIPTION
Setter includecontents false på logging producer listener for å ikke logge content til loggene.
La også til ack: all sånn att vi venter til man skrevet til alle replikas

Defaultoppsett er ellers
https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/kafka/KafkaAutoConfiguration.java 