### PR TITLE
ZonedDateTime deserializer for JdbcUtils

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/util/JdbcObjectMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/util/JdbcObjectMapper.kt
@@ -10,7 +10,7 @@ import no.nav.familie.kontrakter.felles.objectMapper as objectMapperFelles
 
 object JdbcObjectMapper {
 
-    var objectMapper = objectMapperFelles.registerModule(SimpleModule().addDeserializer(ZonedDateTime::class.java,
+    val objectMapper = objectMapperFelles.registerModule(SimpleModule().addDeserializer(ZonedDateTime::class.java,
                                                                                         ZonedDateTimeDeserializer()))
 
 }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/util/JdbcObjectMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/util/JdbcObjectMapper.kt
@@ -1,0 +1,27 @@
+package no.nav.familie.ef.iverksett.util
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.module.SimpleModule
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import no.nav.familie.kontrakter.felles.objectMapper as objectMapperFelles
+
+object JdbcObjectMapper {
+
+    var objectMapper = objectMapperFelles.registerModule(SimpleModule().addDeserializer(ZonedDateTime::class.java,
+                                                                                        ZonedDateTimeDeserializer()))
+
+}
+
+/**
+ * Vi ønsker å defaulte til Europe/Oslo ved deserialisering, i stedet for automatisk ZoneID-justering til UTC
+ */
+private class ZonedDateTimeDeserializer : JsonDeserializer<ZonedDateTime>() {
+
+    override fun deserialize(jsonParser: JsonParser, deserializationContext: DeserializationContext): ZonedDateTime {
+        val string = jsonParser.text
+        return ZonedDateTime.parse(string).withZoneSameInstant(ZoneId.of("Europe/Oslo"))
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/util/JdbcUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/util/JdbcUtil.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ef.iverksett.util
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import no.nav.familie.kontrakter.felles.objectMapper
+
 import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.jdbc.core.RowMapper
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
@@ -12,13 +12,13 @@ import java.util.UUID
 fun ResultSet.getUUID(columnLabel: String): UUID = UUID.fromString(this.getString(columnLabel))
 
 inline fun <reified T> ResultSet.getJson(columnLabel: String): T? {
-    return this.getBytes(columnLabel)?.let { objectMapper.readValue<T>(it) }
+    return this.getBytes(columnLabel)?.let { JdbcObjectMapper.objectMapper.readValue<T>(it) }
 }
 
 inline fun <reified T> NamedParameterJdbcTemplate.queryForJson(sql: String, paramSource: SqlParameterSource): T? {
     try {
         val json = this.queryForObject(sql, paramSource, ByteArray::class.java) ?: return null
-        return objectMapper.readValue<T>(json)
+        return JdbcObjectMapper.objectMapper.readValue<T>(json)
     } catch (emptyResultDataAccess: EmptyResultDataAccessException) {
         return null
     }
@@ -33,3 +33,4 @@ inline fun <reified T> NamedParameterJdbcTemplate.queryForNullableObject(sql: St
         return null
     }
 }
+


### PR DESCRIPTION
DVH ønsker at deres ZonedDateTime typer har en ZoneID som tilsvarer tiden i Norge. Objectmapperen liker å defaulte til UTC ved deserialisering, så legger til en egen. 