### PR TITLE
Simulering returnerer null hvis man simulerer frem i tid

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/OppdragClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/OppdragClient.kt
@@ -52,8 +52,8 @@ class OppdragClient(@Value("\${FAMILIE_OPPDRAG_API_URL}")
         return postForEntity<Ressurs<String>>(konsistensavstemmingUri, konsistensavstemmingUtbetalingsoppdrag).getDataOrThrow()
     }
 
-    fun hentSimulering(utbetalingsoppdrag: Utbetalingsoppdrag): DetaljertSimuleringResultat {
-        return postForEntity<Ressurs<DetaljertSimuleringResultat>>(postSimuleringUri, utbetalingsoppdrag).getDataOrThrow()
+    fun hentSimulering(utbetalingsoppdrag: Utbetalingsoppdrag): DetaljertSimuleringResultat? {
+        return postForEntity<Ressurs<DetaljertSimuleringResultat?>>(postSimuleringUri, utbetalingsoppdrag).getDataOrThrow()
     }
 
     override val pingUri = postOppdragUri

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringController.kt
@@ -21,8 +21,6 @@ class SimuleringController(
 
     @PostMapping
     fun hentSimulering(@RequestBody simuleringDto: SimuleringDto): Ressurs<DetaljertSimuleringResultat> {
-        val detaljertSimuleringResultat =
-                simuleringService.hentSimulering(simuleringDto.toDomain())
-        return Ressurs.success(detaljertSimuleringResultat)
+        return Ressurs.success(simuleringService.hentSimulering(simuleringDto.toDomain()))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringService.kt
@@ -17,18 +17,18 @@ class SimuleringService(
         try {
 
             val forrigeTilkjentYtelse = simulering.forrigeBehandlingId?.let {
-                tilstandRepository.hentTilkjentYtelse(simulering.forrigeBehandlingId)
+                tilstandRepository.hentTilkjentYtelse(it)
             }
 
             val tilkjentYtelseMedUtbetalingsoppdrag = UtbetalingsoppdragGenerator.lagTilkjentYtelseMedUtbetalingsoppdrag(
                     simulering.nyTilkjentYtelseMedMetaData,
-                    forrigeTilkjentYtelse?.let { it } ?: null
+                    forrigeTilkjentYtelse
             )
 
             val utbetalingsoppdrag = tilkjentYtelseMedUtbetalingsoppdrag.utbetalingsoppdrag
                                      ?: error("Utbetalingsoppdraget finnes ikke for tilkjent ytelse")
 
-            return oppdragKlient.hentSimulering(utbetalingsoppdrag)
+            return oppdragKlient.hentSimulering(utbetalingsoppdrag) ?: DetaljertSimuleringResultat(emptyList())
         } catch (feil: Throwable) {
             throw Exception("Henting av simuleringsresultat feilet", feil)
         }


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-6268
Når vi simulerer frem i tid, uten opphør og uten perioder fra før som er frem i tid så får vi null i response.

Vurderte først å prøve å lage en logikk for å ikke simulere når disse tilfellene skjer, men blir unødvendig komplekst. Tror dette kan virke fint. 
https://nav-it.slack.com/archives/C01EH16LAD9/p1631533806015600?thread_ts=1631273076.014100&cid=C01EH16LAD9

Ba gjør i prinsipp noe liknende
https://github.com/navikt/familie-ba-sak/blob/master/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt#L99

```
    fun skalIkkeSimulere(forrigeTilkjentYtelse: TilkjentYtelse?, utbetalingsoppdrag: Utbetalingsoppdrag): Boolean {
        val harOpphørsdatoBakITid = harOpphørsdatoBakITid(utbetalingsoppdrag)
        val harPerioderEtterDagensDato = harPerioderEtterDagensDato(forrigeTilkjentYtelse)
        if (harOpphørsdatoBakITid || harPerioderEtterDagensDato) {
            return false
        }

        return utbetalingsoppdrag.utbetalingsperiode.isEmpty() || harStartdatoFremITid(utbetalingsoppdrag)
    }

    // Hvis man har perioder fra før etter dagens dato får man med neste måneds betaling
    private fun harPerioderEtterDagensDato(tilkjentYtelse: TilkjentYtelse?): Boolean {
        return tilkjentYtelse?.let {
            tilkjentYtelse.andelerTilkjentYtelse
                    .maxOfOrNull { it.tilOgMed }
                    ?.let { LocalDate.now().isBefore(it) }
        } ?: false
    }

    // Hvis man har opphørsdato bak i tid har man en endring i tidligere perioder
    private fun harOpphørsdatoBakITid(utbetalingsoppdrag: Utbetalingsoppdrag): Boolean {
        return utbetalingsoppdrag.utbetalingsperiode
                       .firstOrNull { it.opphør != null }
                       ?.let { it.opphør?.opphørDatoFom }
                       ?.let { LocalDate.now().isAfter(it) }
               ?: false
    }

    // Hvis startdato for nye andeler er frem i tid
    private fun harStartdatoFremITid(utbetalingsoppdrag: Utbetalingsoppdrag) =
            utbetalingsoppdrag.utbetalingsperiode.filter { it.opphør != null }
                    .minOfOrNull { it.vedtakdatoFom }
                    ?.let { LocalDate.now().isBefore(it) }
            ?: false
```
