### PR TITLE
Relatert behandlingId er ikke tatt i bruk enda. Feltet beholdes da de…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/BehandlingDVHMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/BehandlingDVHMapper.kt
@@ -35,7 +35,7 @@ class BehandlingDVHMapper {
         fun map(iverksett: Iverksett, tilkjentYtelse: TilkjentYtelse): BehandlingDVH {
             return BehandlingDVH(fagsakId = iverksett.fagsak.fagsakId.toString(),
                                  behandlingId = iverksett.behandling.behandlingId.toString(),
-                                 relatertBehandlingId = iverksett.behandling.relatertBehandlingId?.toString(),
+                                 relatertBehandlingId = iverksett.behandling.forrigeBehandlingId?.toString(),
                                  adressebeskyttelse = iverksett.søker.adressebeskyttelse?.let { Adressebeskyttelse.valueOf(it.name) },
                                  tidspunktVedtak = iverksett.vedtak.vedtaksdato.atStartOfDay(ZoneId.of("Europe/Oslo")),
                                  vilkårsvurderinger = iverksett.behandling.vilkårsvurderinger.map { mapTilVilkårsvurderinger(it) },


### PR DESCRIPTION
…t antakelig vil bli tatt i bruk når det er støtte for klage, da den kan linkes til første behandling. Sender forrige behandlingId i feltet relatertBehandligId til datavarehus. Oppdaterer datavarehus om disse detaljene (og andre avklaringer i forhold til innhold på data) i eget møte.