### PR TITLE
Legger til saksbehandler og beslutter

### DIFF
--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -45,6 +45,8 @@ spec:
       claims:
         groups:
           - id: "87190cf3-b278-457d-8ab7-1a5c55a9edd7" # Group_87190cf3-b278-457d-8ab7-1a5c55a9edd7 gir tilgang til prosessering
+          - id: "6406aba2-b930-41d3-a85b-dd13731bc974" # 0000-GA-Enslig-Forsorger-Saksbehandler
+          - id: "5fcc0e1d-a4c2-49f0-93dc-27c9fea41e54" # 0000-GA-Enslig-Forsorger-Beslutter
   accessPolicy:
     inbound:
       rules:


### PR DESCRIPTION
For å kunne simulere må saksbehandler og beslutter kunne kalle iverksett via ef-sak

groups er lik ef-sak 
https://github.com/navikt/familie-ef-sak/blob/master/.deploy/vars-prod.yaml

https://logs.adeo.no/goto/df24775a8ba5e7bb205234273840fd30