### PR TITLE
Fiks på 0-beløp i tilkjente ytelser i vedtakstatistikk-mapping:

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/BehandlingDVHMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/BehandlingDVHMapper.kt
@@ -30,7 +30,7 @@ import no.nav.familie.eksterne.kontrakter.ef.StønadType as StønadTypeEkstern
 
 object BehandlingDVHMapper {
 
-    fun map(iverksett: Iverksett, tilkjentYtelse: TilkjentYtelse?): BehandlingDVH {
+    fun map(iverksett: Iverksett): BehandlingDVH {
         return BehandlingDVH(fagsakId = iverksett.fagsak.fagsakId.toString(),
                              behandlingId = iverksett.behandling.behandlingId.toString(),
                              relatertBehandlingId = iverksett.behandling.forrigeBehandlingId?.toString(),
@@ -45,7 +45,7 @@ object BehandlingDVHMapper {
                              behandlingÅrsak = BehandlingÅrsak.valueOf(iverksett.behandling.behandlingÅrsak.name),
                              vedtak = Vedtak.valueOf(iverksett.vedtak.vedtaksresultat.name),
                              vedtaksperioder = mapToVedtaksperioder(iverksett.vedtak.vedtaksperioder),
-                             utbetalinger = tilkjentYtelse?.let {
+                             utbetalinger = iverksett.vedtak.tilkjentYtelse?.let {
                                  mapTilUtbetaling(it,
                                                   iverksett.fagsak.stønadstype,
                                                   iverksett.fagsak.eksternId,
@@ -76,7 +76,7 @@ object BehandlingDVHMapper {
                     tilOgMed = it.tilOgMed,
                     Utbetalingsdetalj(gjelderPerson = mapTilPerson(personIdent = søker.personIdent),
                                       klassekode = stønadsType.tilKlassifisering(),
-                                      delytelseId = eksternFagsakId.toString() + it.periodeId))
+                                      delytelseId = eksternFagsakId.toString() + (it.periodeId ?: "")))
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkService.kt
@@ -8,13 +8,13 @@ import org.springframework.stereotype.Service
 @Service
 class VedtakstatistikkService(private val vedtakstatistikkKafkaProducer: VedtakstatistikkKafkaProducer) {
 
-    fun sendTilKafka(iverksett: Iverksett, tilkjentYtelse: TilkjentYtelse?) {
-        val vedtakstatistikk = hentBehandlingDVH(iverksett, tilkjentYtelse)
+    fun sendTilKafka(iverksett: Iverksett) {
+        val vedtakstatistikk = hentBehandlingDVH(iverksett)
         vedtakstatistikkKafkaProducer.sendVedtak(vedtakstatistikk)
     }
 
-    private fun hentBehandlingDVH(iverksett: Iverksett, tilkjentYtelse: TilkjentYtelse?): BehandlingDVH {
-        return BehandlingDVHMapper.map(iverksett, tilkjentYtelse)
+    private fun hentBehandlingDVH(iverksett: Iverksett): BehandlingDVH {
+        return BehandlingDVHMapper.map(iverksett)
 
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkTask.kt
@@ -19,8 +19,7 @@ class VedtakstatistikkTask(private val iverksettingRepository: IverksettingRepos
     override fun doTask(task: Task) {
         val behandlingId = UUID.fromString(task.payload)
         val iverksett = iverksettingRepository.hent(behandlingId)
-        val tilkjentYtelse = tilstandRepository.hentTilkjentYtelse(behandlingId)
-        vedtakstatistikkService.sendTilKafka(iverksett, tilkjentYtelse)
+        vedtakstatistikkService.sendTilKafka(iverksett)
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkTestController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkTestController.kt
@@ -25,7 +25,7 @@ class VedtakstatistikkTestController(
 
     @PostMapping("/", consumes = [MediaType.APPLICATION_JSON_VALUE])
     fun sendStatistikk(@RequestBody data: IverksettDto) {
-        vedtakstatistikkService.sendTilKafka(data.toDomain(), opprettTilkjentYtelse())
+        vedtakstatistikkService.sendTilKafka(data.toDomain())
     }
 
     private fun opprettTilkjentYtelse(): TilkjentYtelse {

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/BehandlingDVHMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/BehandlingDVHMapperTest.kt
@@ -107,28 +107,7 @@ internal class BehandlingDVHMapperTest {
                                                                           tilOgMed = LocalDate.of(2021, 10, 31))
                                                    ))
 
-                ),
-                TilkjentYtelse(andelerTilkjentYtelse = listOf(AndelTilkjentYtelse(beløp = 8000,
-                                                                                  fraOgMed = LocalDate.of(2021, 1, 1),
-                                                                                  tilOgMed = LocalDate.of(2021, 5, 31),
-                                                                                  periodetype = Periodetype.MÅNED,
-                                                                                  inntekt = 400000,
-                                                                                  samordningsfradrag = 1000,
-                                                                                  inntektsreduksjon = 11000,
-                                                                                  periodeId = 1,
-                                                                                  forrigePeriodeId = null,
-                                                                                  kildeBehandlingId = behandlingId
-                ),
-                                                              AndelTilkjentYtelse(beløp = 30000,
-                                                                                  fraOgMed = LocalDate.of(2021, 6, 1),
-                                                                                  tilOgMed = LocalDate.of(2021, 10, 31),
-                                                                                  periodetype = Periodetype.MÅNED,
-                                                                                  inntekt = 400000,
-                                                                                  samordningsfradrag = 0,
-                                                                                  inntektsreduksjon = 11000,
-                                                                                  periodeId = 2,
-                                                                                  forrigePeriodeId = 1,
-                                                                                  kildeBehandlingId = behandlingId)))
+                )
         )
 
         assertThat(behandlingDVH.aktivitetskrav.harSagtOppArbeidsforhold).isFalse()

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkServiceTest.kt
@@ -10,7 +10,6 @@ import io.mockk.verify
 import no.nav.familie.ef.iverksett.ResourceLoaderTestUtil
 import no.nav.familie.ef.iverksett.infrastruktur.transformer.toDomain
 import no.nav.familie.ef.iverksett.util.opprettIverksett
-import no.nav.familie.ef.iverksett.util.opprettTilkjentYtelse
 import no.nav.familie.eksterne.kontrakter.ef.Adressebeskyttelse
 import no.nav.familie.eksterne.kontrakter.ef.AktivitetType
 import no.nav.familie.eksterne.kontrakter.ef.Aktivitetskrav
@@ -49,7 +48,7 @@ class VedtakstatistikkServiceTest {
         every { vedtakstatistikkKafkaProducer.sendVedtak(capture(behandlingDvhSlot)) } just Runs
 
         val iverksett = opprettIverksett(behandlingId)
-        vedtakstatistikkService.sendTilKafka(iverksett = iverksett, opprettTilkjentYtelse(behandlingId))
+        vedtakstatistikkService.sendTilKafka(iverksett = iverksett)
         verify(exactly = 1) { vedtakstatistikkKafkaProducer.sendVedtak(any()) }
 
         val behandlingDVH = opprettBehandlingDVH(behandlingId = behandlingId.toString(),
@@ -67,7 +66,7 @@ class VedtakstatistikkServiceTest {
 
         val behandlingDvhSlot = slot<BehandlingDVH>()
         every { vedtakstatistikkKafkaProducer.sendVedtak(capture(behandlingDvhSlot)) } just Runs
-        vedtakstatistikkService.sendTilKafka(iverksett, opprettTilkjentYtelse(iverksett.behandling.behandlingId))
+        vedtakstatistikkService.sendTilKafka(iverksett)
 
         assertThat(behandlingDvhSlot.captured).isNotNull
         assertThat(behandlingDvhSlot.captured.vilkårsvurderinger.size).isEqualTo(2)
@@ -97,7 +96,7 @@ class VedtakstatistikkServiceTest {
                                                                         aktivitet = AktivitetType.BARNET_ER_SYKT,
                                                                         periodeType = VedtaksperiodeType.HOVEDPERIODE)),
                              utbetalinger = listOf(Utbetaling(
-                                     beløp = 100,
+                                     beløp = 5000,
                                      fraOgMed = LocalDate.parse("2021-01-01"),
                                      tilOgMed = LocalDate.parse("2021-12-31"),
                                      inntekt = 100,
@@ -105,7 +104,7 @@ class VedtakstatistikkServiceTest {
                                      samordningsfradrag = 2,
                                      utbetalingsdetalj = Utbetalingsdetalj(klassekode = "EFOG",
                                                                            gjelderPerson = Person(personIdent = "12345678910"),
-                                                                           delytelseId = "11"))),
+                                                                           delytelseId = "1"))),
 
                              aktivitetskrav = Aktivitetskrav(aktivitetspliktInntrefferDato = null,
                                                              harSagtOppArbeidsforhold = true),

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkTaskTest.kt
@@ -28,10 +28,10 @@ internal class VedtakstatistikkTaskTest {
     @Test
     fun `skal sende vedtaksstatistikk til DVH`() {
         val behandlingIdString = behandlingId.toString()
-        every { vedtakstatistikkService.sendTilKafka(any(), any()) } just Runs
+        every { vedtakstatistikkService.sendTilKafka(any()) } just Runs
         every { tilstandRepository.hentTilkjentYtelse(behandlingId) } returns opprettTilkjentYtelse(behandlingId)
         every { iverksettingRepository.hent(behandlingId) }.returns(opprettIverksettDto(behandlingId = behandlingId).toDomain())
         vedtakstatistikkTask.doTask(Task(VedtakstatistikkTask.TYPE, behandlingIdString, Properties()))
-        verify(exactly = 1) { vedtakstatistikkService.sendTilKafka(any(), any()) }
+        verify(exactly = 1) { vedtakstatistikkService.sendTilKafka(any()) }
     }
 }


### PR DESCRIPTION
Henter ut andelTilkjentYtelse fra iverksett-tabell og ikke fra iverksett_resultat da andelTilkjentYtelse ikke blir populert i tilfeller hvor det er 0-beløp i tilkjent ytelse. Oppdrag bryr seg ikke om 0-beløp og det er derfor bedre og mer komplette data i iverksett-tabellen.
Ikke skriv ut periodeId i delytelse dersom den er null, noe som den gjerne er dersom tilkjent ytelse er 0 beløp.