### PR TITLE
Fix/simulering etterbetaling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringController.kt
@@ -38,18 +38,4 @@ class SimuleringController(
                 simuleringService.hentBeriketSimulering(simuleringDto.toDomain())
         return Ressurs.success(beriketSimuleringResultat)
     }
-
-    @PostMapping("v2/korrigering")
-    fun fiksSimuleringV2(@RequestBody beriketSimuleringsresultat: BeriketSimuleringsresultat): Ressurs<BeriketSimuleringsresultat> {
-
-        if (beriketSimuleringsresultat.oppsummering.tidSimuleringHentet==null) {
-            throw ApiFeil("Kan ikke korrigere når simuleringsoppsummeringen mangler tidSimuleringHentet", HttpStatus.BAD_REQUEST)
-        }
-
-        val oppsummering = lagSimuleringsoppsummering(
-                beriketSimuleringsresultat.detaljer,
-                beriketSimuleringsresultat.oppsummering.tidSimuleringHentet!!)
-        
-        return Ressurs.success(beriketSimuleringsresultat.copy(oppsummering = oppsummering))
-    }
 }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringController.kt
@@ -1,11 +1,15 @@
 package no.nav.familie.ef.iverksett.økonomi.simulering
 
+import no.nav.familie.ef.iverksett.infrastruktur.advice.ApiFeil
 import no.nav.familie.ef.iverksett.infrastruktur.transformer.toDomain
+import no.nav.familie.kontrakter.ef.felles.Vedtaksresultat
 import no.nav.familie.kontrakter.ef.iverksett.SimuleringDto
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.simulering.DetaljertSimuleringResultat
 import no.nav.familie.kontrakter.felles.simulering.BeriketSimuleringsresultat
+import no.nav.familie.kontrakter.felles.simulering.Simuleringsoppsummering
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -33,5 +37,19 @@ class SimuleringController(
         val beriketSimuleringResultat =
                 simuleringService.hentBeriketSimulering(simuleringDto.toDomain())
         return Ressurs.success(beriketSimuleringResultat)
+    }
+
+    @PostMapping("v2/korrigering")
+    fun fiksSimuleringV2(@RequestBody beriketSimuleringsresultat: BeriketSimuleringsresultat): Ressurs<BeriketSimuleringsresultat> {
+
+        if (beriketSimuleringsresultat.oppsummering.tidSimuleringHentet==null) {
+            throw ApiFeil("Kan ikke korrigere når simuleringsoppsummeringen mangler tidSimuleringHentet", HttpStatus.BAD_REQUEST)
+        }
+
+        val oppsummering = lagSimuleringsoppsummering(
+                beriketSimuleringsresultat.detaljer,
+                beriketSimuleringsresultat.oppsummering.tidSimuleringHentet!!)
+        
+        return Ressurs.success(beriketSimuleringsresultat.copy(oppsummering = oppsummering))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringUtil.kt
@@ -15,8 +15,7 @@ import java.math.BigDecimal.ZERO
 import java.time.LocalDate
 import java.util.WeakHashMap
 
-fun lagSimuleringsoppsummering(detaljertSimuleringResultat: DetaljertSimuleringResultat,
-                               tidSimuleringHentet: LocalDate): Simuleringsoppsummering {
+fun lagSimuleringsoppsummering(detaljertSimuleringResultat: DetaljertSimuleringResultat, tidSimuleringHentet: LocalDate): Simuleringsoppsummering {
     val perioder = grupperPosteringerEtterDato(detaljertSimuleringResultat.simuleringMottaker)
 
     val framtidigePerioder =
@@ -80,7 +79,7 @@ private fun hentTidligereUtbetalt(posteringer: List<SimulertPostering>): BigDeci
             .sumOf { it.beløp }
 
     val negativFeilutbetaling = minOf(hentFeilutbetaling(posteringer), ZERO)
-    return -(sumNegativeYtelser - negativFeilutbetaling)
+    return negativFeilutbetaling - sumNegativeYtelser
 }
 
 private fun hentResultat(posteringer: List<SimulertPostering>): BigDecimal {
@@ -125,6 +124,7 @@ private data class PeriodeMedForfall(
 )
 
 private object SimuleringsperiodeEtterbetaling {
+
     // Simuleringsperiode mangler etterbetaling. Dette er et lite påbygg for å emulere at det finnes.
     fun Simuleringsperiode.medEtterbetaling(etterbetaling: BigDecimal?): Simuleringsperiode {
         simuleringsperiodeEtterbetalingMap[this] = etterbetaling
@@ -134,7 +134,7 @@ private object SimuleringsperiodeEtterbetaling {
     val Simuleringsperiode.etterbetaling: BigDecimal?
         get() = simuleringsperiodeEtterbetalingMap[this]
 
-    private val simuleringsperiodeEtterbetalingMap = WeakHashMap<Simuleringsperiode,BigDecimal?>()
+    private val simuleringsperiodeEtterbetalingMap = WeakHashMap<Simuleringsperiode, BigDecimal?>()
 }
 
 fun BeriketSimuleringsresultat.harFeilutbetaling(): Boolean {

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringUtil.kt
@@ -62,9 +62,9 @@ private fun hentNyttBeløp(posteringer: List<SimulertPostering>): BigDecimal {
             .filter { it.posteringType == YTELSE && it.beløp > ZERO }
             .sumOf { it.beløp }
 
-    val feilutbetaling =  hentFeilutbetaling(posteringer)
+    val positivFeilutbetaling =  maxOf(hentFeilutbetaling(posteringer), ZERO)
 
-    return if (feilutbetaling > ZERO) sumPositiveYtelser - feilutbetaling else sumPositiveYtelser
+    return sumPositiveYtelser - positivFeilutbetaling
 }
 
 private fun hentFeilutbetaling(posteringer: List<SimulertPostering>) =
@@ -77,8 +77,8 @@ private fun hentTidligereUtbetalt(posteringer: List<SimulertPostering>): BigDeci
             .filter { it.posteringType === YTELSE && it.beløp < ZERO }
             .sumOf { it.beløp }
 
-    val feilutbetaling = hentFeilutbetaling(posteringer)
-    return if (feilutbetaling < ZERO) -(sumNegativeYtelser - feilutbetaling) else -sumNegativeYtelser
+    val negativFeilutbetaling = minOf(hentFeilutbetaling(posteringer), ZERO)
+    return -(sumNegativeYtelser - negativFeilutbetaling)
 }
 
 private fun hentResultat(posteringer: List<SimulertPostering>): BigDecimal {
@@ -107,7 +107,7 @@ private fun hentEtterbetaling(posteringer: List<SimulertPostering>): BigDecimal 
 
 private fun hentTotalEtterbetaling(simuleringsperioder: List<Simuleringsperiode>, fomDatoNestePeriode: LocalDate?) =
         simuleringsperioder
-                .filter { (fomDatoNestePeriode == null || it.fom < fomDatoNestePeriode) }
+                .filter { fomDatoNestePeriode == null || it.fom < fomDatoNestePeriode }
                 .sumOf { it.etterbetaling ?: ZERO }
                 .let { maxOf(it, ZERO) }
 

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringUtil.kt
@@ -1,10 +1,19 @@
 package no.nav.familie.ef.iverksett.økonomi.simulering
 
-import no.nav.familie.kontrakter.felles.simulering.*
+import no.nav.familie.kontrakter.felles.simulering.BeriketSimuleringsresultat
+import no.nav.familie.kontrakter.felles.simulering.DetaljertSimuleringResultat
+import no.nav.familie.kontrakter.felles.simulering.PosteringType.FEILUTBETALING
+import no.nav.familie.kontrakter.felles.simulering.PosteringType.YTELSE
+import no.nav.familie.kontrakter.felles.simulering.SimuleringMottaker
+import no.nav.familie.kontrakter.felles.simulering.Simuleringsoppsummering
+import no.nav.familie.kontrakter.felles.simulering.Simuleringsperiode
+import no.nav.familie.kontrakter.felles.simulering.SimulertPostering
 import java.math.BigDecimal
+import java.math.BigDecimal.ZERO
 import java.time.LocalDate
 
-fun lagSimuleringsoppsummering(detaljertSimuleringResultat: DetaljertSimuleringResultat, tidSimuleringHentet: LocalDate): Simuleringsoppsummering {
+fun lagSimuleringsoppsummering(detaljertSimuleringResultat: DetaljertSimuleringResultat,
+                               tidSimuleringHentet: LocalDate): Simuleringsoppsummering {
     val perioder = grupperPosteringerEtterDato(detaljertSimuleringResultat.simuleringMottaker)
 
     val framtidigePerioder =
@@ -13,14 +22,14 @@ fun lagSimuleringsoppsummering(detaljertSimuleringResultat: DetaljertSimuleringR
                 (it.tom > tidSimuleringHentet && it.forfallsdato > tidSimuleringHentet)
             }
 
-    val nestePeriode = framtidigePerioder.filter { it.feilutbetaling == BigDecimal.ZERO }.minByOrNull { it.fom }
+    val nestePeriode = framtidigePerioder.filter { it.feilutbetaling == ZERO }.minByOrNull { it.fom }
     val tomSisteUtbetaling = perioder.filter { nestePeriode == null || it.fom < nestePeriode.fom }.maxOfOrNull { it.tom }
 
     return Simuleringsoppsummering(
             perioder = perioder,
             fomDatoNestePeriode = nestePeriode?.fom,
             etterbetaling = hentTotalEtterbetaling(perioder, nestePeriode?.fom),
-            feilutbetaling = hentTotalFeilutbetaling(perioder, nestePeriode?.fom),
+            feilutbetaling = hentTotalFeilutbetaling(perioder, nestePeriode?.fom).let { maxOf(it, ZERO) },
             fom = perioder.minOfOrNull { it.fom },
             tomDatoNestePeriode = nestePeriode?.tom,
             forfallsdatoNestePeriode = nestePeriode?.forfallsdato,
@@ -29,69 +38,90 @@ fun lagSimuleringsoppsummering(detaljertSimuleringResultat: DetaljertSimuleringR
     )
 }
 
-private fun grupperPosteringerEtterDato(mottakere: List<SimuleringMottaker>): List<Simuleringsperiode> {
-    val simuleringsperioder = mutableMapOf<LocalDate, MutableList<SimulertPostering>>()
-
-    mottakere.forEach {
-        it.simulertPostering.filter { it.posteringType == PosteringType.YTELSE || it.posteringType == PosteringType.FEILUTBETALING }
-                .forEach { postering ->
-                    if (simuleringsperioder.containsKey(postering.fom))
-                        simuleringsperioder[postering.fom]?.add(postering)
-                    else simuleringsperioder[postering.fom] = mutableListOf(postering)
-                }
-    }
-
-    return simuleringsperioder.map { (fom, posteringListe) ->
-        Simuleringsperiode(
-                fom,
-                posteringListe[0].tom,
-                posteringListe[0].forfallsdato,
-                nyttBeløp = hentNyttBeløp(posteringListe),
-                tidligereUtbetalt = hentTidligereUtbetalt(posteringListe),
-                resultat = hentResultat(posteringListe),
-                feilutbetaling = hentFeilutbetaling(posteringListe),
-        )
-    }
+fun grupperPosteringerEtterDato(mottakere: List<SimuleringMottaker>): List<Simuleringsperiode> {
+    return mottakere
+            .flatMap { it.simulertPostering }
+            .filter { it.posteringType == FEILUTBETALING || it.posteringType == YTELSE }
+            .groupBy { PeriodeMedForfall(fom = it.fom, tom = it.tom, forfallsdato = it.forfallsdato) }
+            .map { (periodeMedForfall, posteringListe) ->
+                Simuleringsperiode(
+                        periodeMedForfall.fom,
+                        periodeMedForfall.tom,
+                        periodeMedForfall.forfallsdato,
+                        nyttBeløp = hentNyttBeløp(posteringListe),
+                        tidligereUtbetalt = hentTidligereUtbetalt(posteringListe),
+                        resultat = hentResultat(posteringListe),
+                        feilutbetaling = hentFeilutbetaling(posteringListe),
+                        etterbetaling = hentEtterbetaling(posteringListe)
+                )
+            }
 }
 
 private fun hentNyttBeløp(posteringer: List<SimulertPostering>): BigDecimal {
-    val sumPositiveYtelser = posteringer.filter { postering ->
-        postering.posteringType == PosteringType.YTELSE && postering.beløp > BigDecimal.ZERO
-    }.sumOf { it.beløp }
-    val feilutbetaling = hentFeilutbetaling(posteringer)
-    return if (feilutbetaling > BigDecimal.ZERO) sumPositiveYtelser - feilutbetaling else sumPositiveYtelser
+    val sumPositiveYtelser = posteringer
+            .filter { it.posteringType == YTELSE && it.beløp > ZERO }
+            .sumOf { it.beløp }
+
+    val feilutbetaling =  hentFeilutbetaling(posteringer)
+
+    return if (feilutbetaling > ZERO) sumPositiveYtelser - feilutbetaling else sumPositiveYtelser
 }
 
 private fun hentFeilutbetaling(posteringer: List<SimulertPostering>) =
-        posteringer.filter { postering ->
-            postering.posteringType == PosteringType.FEILUTBETALING
-        }.sumOf { it.beløp }
+        posteringer
+                .filter { it.posteringType == FEILUTBETALING }
+                .sumOf { it.beløp }
 
 private fun hentTidligereUtbetalt(posteringer: List<SimulertPostering>): BigDecimal {
-    val sumNegativeYtelser = posteringer.filter { postering ->
-        (postering.posteringType === PosteringType.YTELSE && postering.beløp < BigDecimal.ZERO)
-    }.sumOf { -it.beløp }
+    val sumNegativeYtelser = posteringer
+            .filter { it.posteringType === YTELSE && it.beløp < ZERO }
+            .sumOf { it.beløp }
+
     val feilutbetaling = hentFeilutbetaling(posteringer)
-    return if (feilutbetaling < BigDecimal.ZERO) sumNegativeYtelser - feilutbetaling else sumNegativeYtelser
+    return if (feilutbetaling < ZERO) -(sumNegativeYtelser - feilutbetaling) else -sumNegativeYtelser
 }
 
-private fun hentResultat(posteringer: List<SimulertPostering>) =
-        if (posteringer.map { it.posteringType }.contains(PosteringType.FEILUTBETALING)) {
-            posteringer.filter {
-                it.posteringType == PosteringType.FEILUTBETALING
-            }.sumOf { -it.beløp }
-        } else
-            posteringer.sumOf { it.beløp }
+private fun hentResultat(posteringer: List<SimulertPostering>): BigDecimal {
+    val posteringerHarFeilutbetaling = posteringer.any { it.posteringType == FEILUTBETALING }
+    return when {
+        posteringerHarFeilutbetaling -> posteringer
+                .filter { it.posteringType == FEILUTBETALING }
+                .sumOf { -it.beløp }
+        else -> posteringer.sumOf { it.beløp }
+    }
+}
 
-private fun hentTotalEtterbetaling(simuleringPerioder: List<Simuleringsperiode>, fomDatoNestePeriode: LocalDate?) =
-        simuleringPerioder.filter {
-            it.resultat > BigDecimal.ZERO && (fomDatoNestePeriode == null || it.fom < fomDatoNestePeriode)
-        }.sumOf { it.resultat }
+private fun hentEtterbetaling(posteringer: List<SimulertPostering>): BigDecimal {
+    val posteringerHarPositivFeilutbetaling =
+            posteringer.any { it.posteringType == FEILUTBETALING && it.beløp > ZERO }
 
+    val sumYtelser = posteringer
+            .filter { it.posteringType == YTELSE }
+            .sumOf { it.beløp }
 
-private fun hentTotalFeilutbetaling(simuleringPerioder: List<Simuleringsperiode>, fomDatoNestePeriode: LocalDate?) =
-        simuleringPerioder.filter { fomDatoNestePeriode == null || it.fom < fomDatoNestePeriode }.sumOf { it.feilutbetaling }
+    return when {
+        posteringerHarPositivFeilutbetaling -> ZERO
+        else -> maxOf(sumYtelser, ZERO)
+    }
+}
+
+private fun hentTotalEtterbetaling(simuleringsperioder: List<Simuleringsperiode>, fomDatoNestePeriode: LocalDate?) =
+        simuleringsperioder
+                .filter { (fomDatoNestePeriode == null || it.fom < fomDatoNestePeriode) }
+                .sumOf { it.etterbetaling ?: ZERO }
+                .let { maxOf(it, ZERO) }
+
+private fun hentTotalFeilutbetaling(simuleringsperioder: List<Simuleringsperiode>, fomDatoNestePeriode: LocalDate?) =
+        simuleringsperioder
+                .filter { fomDatoNestePeriode == null || it.fom < fomDatoNestePeriode }
+                .sumOf { it.feilutbetaling }
+
+private data class PeriodeMedForfall(
+        val fom: LocalDate,
+        val tom: LocalDate,
+        val forfallsdato: LocalDate
+)
 
 fun BeriketSimuleringsresultat.harFeilutbetaling(): Boolean {
-        return this.oppsummering.feilutbetaling > BigDecimal.ZERO
+    return this.oppsummering.feilutbetaling > ZERO
 }

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
@@ -20,6 +20,7 @@ import no.nav.familie.kontrakter.felles.simulering.SimulertPostering
 import no.nav.familie.kontrakter.felles.tilbakekreving.Periode
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.time.YearMonth
 import java.time.temporal.TemporalAdjusters
 import java.util.UUID
 import no.nav.familie.kontrakter.ef.iverksett.TilkjentYtelseMedMetadata as TilkjentYtelseMedMetadataDto
@@ -88,7 +89,8 @@ fun simuleringsoppsummering(
                         nyttBeløp = BigDecimal.valueOf(15000),
                         tidligereUtbetalt = BigDecimal.ZERO,
                         resultat = BigDecimal.valueOf(15000),
-                        feilutbetaling = feilutbetaling
+                        feilutbetaling = feilutbetaling,
+                        etterbetaling = BigDecimal.valueOf(15000)
                 )),
                 etterbetaling = BigDecimal.valueOf(15000),
                 feilutbetaling = feilutbetaling,
@@ -100,19 +102,19 @@ fun simuleringsoppsummering(
                 tomSisteUtbetaling = tom
         )
 
-fun posteringer(fraDato: LocalDate,
+fun posteringer(fraDato: YearMonth,
                 antallMåneder: Int = 1,
-                beløp: BigDecimal = BigDecimal(5000),
+                beløp: Int = 5000,
                 posteringstype: PosteringType = PosteringType.YTELSE
 
 ): List<SimulertPostering> = MutableList(antallMåneder) { index ->
     SimulertPostering(fagOmrådeKode = FagOmrådeKode.ENSLIG_FORSØRGER_OVERGANGSSTØNAD,
-                      fom = fraDato.plusMonths(index.toLong()),
-                      tom = fraDato.plusMonths(index.toLong()).with(TemporalAdjusters.lastDayOfMonth()),
+                      fom = fraDato.plusMonths(index.toLong()).atDay(1),
+                      tom = fraDato.plusMonths(index.toLong()).atEndOfMonth(),
                       betalingType = BetalingType.DEBIT,
-                      beløp = beløp,
+                      beløp = beløp.toBigDecimal(),
                       posteringType = posteringstype,
-                      forfallsdato = fraDato.plusMonths(index.toLong()).with(TemporalAdjusters.lastDayOfMonth()),
+                      forfallsdato = fraDato.plusMonths(index.toLong()).atEndOfMonth(),
                       utenInntrekk = false)
 }
 

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
@@ -90,8 +90,7 @@ fun simuleringsoppsummering(
                         nyttBeløp = BigDecimal.valueOf(15000),
                         tidligereUtbetalt = BigDecimal.ZERO,
                         resultat = BigDecimal.valueOf(15000),
-                        feilutbetaling = feilutbetaling,
-                        //etterbetaling = BigDecimal.valueOf(15000)
+                        feilutbetaling = feilutbetaling
                 )),
                 etterbetaling = BigDecimal.valueOf(15000),
                 feilutbetaling = feilutbetaling,

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.iverksett
 
 import no.nav.familie.ef.iverksett.iverksetting.domene.Tilbakekrevingsdetaljer
 import no.nav.familie.ef.iverksett.økonomi.lagAndelTilkjentYtelseDto
+import no.nav.familie.ef.iverksett.økonomi.simulering.grupperPosteringerEtterDato
 import no.nav.familie.kontrakter.ef.felles.StønadType
 import no.nav.familie.kontrakter.ef.iverksett.AndelTilkjentYtelseDto
 import no.nav.familie.kontrakter.ef.iverksett.Periodetype
@@ -125,3 +126,18 @@ fun Tilbakekrevingsdetaljer.medFeilutbetaling(feilutbetaling: BigDecimal, period
                           perioder = listOf(periode)
                   )
         )
+
+fun Int.januar(år: Int) = LocalDate.of(år, 1, this)
+fun Int.august(år: Int) = LocalDate.of(år, 8, this)
+fun januar(år: Int) = YearMonth.of(år, 1)
+fun februar(år: Int) = YearMonth.of(år, 2)
+fun juli(år: Int) = YearMonth.of(år, 7)
+
+fun List<SimulertPostering>.tilSimuleringsperioder() =
+        grupperPosteringerEtterDato(this.tilSimuleringMottakere())
+
+fun List<SimulertPostering>.tilSimuleringMottakere() =
+        listOf(SimuleringMottaker(this, "12345678901", MottakerType.BRUKER))
+
+fun List<SimulertPostering>.tilDetaljertSimuleringsresultat() =
+        DetaljertSimuleringResultat(this.tilSimuleringMottakere())

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
@@ -105,7 +105,7 @@ fun posteringer(måned: YearMonth = januar(2021),
                 antallMåneder: Int = 1,
                 beløp: Int = 5000,
                 posteringstype: PosteringType = PosteringType.YTELSE,
-                betalingstype: BetalingType = BetalingType.DEBIT
+                betalingstype: BetalingType = if (beløp >=0) BetalingType.DEBIT else BetalingType.KREDIT
 
 ): List<SimulertPostering> = MutableList(antallMåneder) { index ->
     SimulertPostering(fagOmrådeKode = FagOmrådeKode.ENSLIG_FORSØRGER_OVERGANGSSTØNAD,
@@ -129,9 +129,13 @@ fun Tilbakekrevingsdetaljer.medFeilutbetaling(feilutbetaling: BigDecimal, period
 fun Int.januar(år: Int) = LocalDate.of(år, 1, this)
 fun Int.februar(år: Int) = LocalDate.of(år, 2, this)
 fun Int.august(år: Int) = LocalDate.of(år, 8, this)
+fun Int.november(år: Int) = LocalDate.of(år, 11, this)
+
 fun januar(år: Int) = YearMonth.of(år, 1)
 fun februar(år: Int) = YearMonth.of(år, 2)
+fun mai(år: Int) = YearMonth.of(år,5)
 fun juli(år: Int) = YearMonth.of(år, 7)
+fun september(år: Int) = YearMonth.of(år, 9)
 
 fun List<SimulertPostering>.tilSimuleringsperioder() =
         grupperPosteringerEtterDato(this.tilSimuleringMottakere())

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
@@ -22,7 +22,6 @@ import no.nav.familie.kontrakter.felles.tilbakekreving.Periode
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
-import java.time.temporal.TemporalAdjusters
 import java.util.UUID
 import no.nav.familie.kontrakter.ef.iverksett.TilkjentYtelseMedMetadata as TilkjentYtelseMedMetadataDto
 
@@ -102,20 +101,21 @@ fun simuleringsoppsummering(
                 tomSisteUtbetaling = tom
         )
 
-fun posteringer(fraDato: YearMonth,
+fun posteringer(måned: YearMonth = januar(2021),
                 antallMåneder: Int = 1,
                 beløp: Int = 5000,
-                posteringstype: PosteringType = PosteringType.YTELSE
+                posteringstype: PosteringType = PosteringType.YTELSE,
+                betalingstype: BetalingType = BetalingType.DEBIT
 
 ): List<SimulertPostering> = MutableList(antallMåneder) { index ->
     SimulertPostering(fagOmrådeKode = FagOmrådeKode.ENSLIG_FORSØRGER_OVERGANGSSTØNAD,
-                      fom = fraDato.plusMonths(index.toLong()).atDay(1),
-                      tom = fraDato.plusMonths(index.toLong()).atEndOfMonth(),
-                      betalingType = BetalingType.DEBIT,
+                      fom = måned.plusMonths(index.toLong()).atDay(1),
+                      tom = måned.plusMonths(index.toLong()).atEndOfMonth(),
+                      betalingType = betalingstype,
                       beløp = beløp.toBigDecimal(),
                       posteringType = posteringstype,
-                      forfallsdato = fraDato.plusMonths(index.toLong()).atEndOfMonth(),
-                      utenInntrekk = false)
+                      forfallsdato = måned.plusMonths(index.toLong()).atEndOfMonth(), // Forfallsdato i bank (dagen går til brukeren). Det sendes til banken kanskje en uke i forveien
+                      utenInntrekk = false) // Brukes ikke for EF
 }
 
 fun Tilbakekrevingsdetaljer.medFeilutbetaling(feilutbetaling: BigDecimal, periode: Periode) =
@@ -127,6 +127,7 @@ fun Tilbakekrevingsdetaljer.medFeilutbetaling(feilutbetaling: BigDecimal, period
         )
 
 fun Int.januar(år: Int) = LocalDate.of(år, 1, this)
+fun Int.februar(år: Int) = LocalDate.of(år, 2, this)
 fun Int.august(år: Int) = LocalDate.of(år, 8, this)
 fun januar(år: Int) = YearMonth.of(år, 1)
 fun februar(år: Int) = YearMonth.of(år, 2)

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
@@ -91,7 +91,7 @@ fun simuleringsoppsummering(
                         tidligereUtbetalt = BigDecimal.ZERO,
                         resultat = BigDecimal.valueOf(15000),
                         feilutbetaling = feilutbetaling,
-                        etterbetaling = BigDecimal.valueOf(15000)
+                        //etterbetaling = BigDecimal.valueOf(15000)
                 )),
                 etterbetaling = BigDecimal.valueOf(15000),
                 feilutbetaling = feilutbetaling,

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringUtilTest.kt
@@ -1,19 +1,21 @@
 package no.nav.familie.ef.iverksett.økonomi.simulering
 
+import no.nav.familie.ef.iverksett.august
+import no.nav.familie.ef.iverksett.februar
+import no.nav.familie.ef.iverksett.januar
+import no.nav.familie.ef.iverksett.juli
 import no.nav.familie.ef.iverksett.posteringer
-import no.nav.familie.kontrakter.felles.simulering.DetaljertSimuleringResultat
-import no.nav.familie.kontrakter.felles.simulering.MottakerType
+import no.nav.familie.ef.iverksett.tilDetaljertSimuleringsresultat
+import no.nav.familie.ef.iverksett.tilSimuleringMottakere
+import no.nav.familie.ef.iverksett.tilSimuleringsperioder
 import no.nav.familie.kontrakter.felles.simulering.PosteringType
 import no.nav.familie.kontrakter.felles.simulering.PosteringType.FEILUTBETALING
 import no.nav.familie.kontrakter.felles.simulering.PosteringType.YTELSE
-import no.nav.familie.kontrakter.felles.simulering.SimuleringMottaker
 import no.nav.familie.kontrakter.felles.simulering.SimulertPostering
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
-import java.time.LocalDate
-import java.time.YearMonth
 
 internal class SimuleringUtilTest {
 
@@ -26,13 +28,13 @@ internal class SimuleringUtilTest {
                 posteringer(januar(2020), posteringstype = PosteringType.JUSTERING)+
                 posteringer(januar(2020), posteringstype = PosteringType.TREKK)
 
-        val simuleringsresultatDto = lagSimuleringsoppsummering(
+        val simuleringsoppsummering = lagSimuleringsoppsummering(
                 posteringer.tilDetaljertSimuleringsresultat(),
                 1.januar(2021))
 
-        assertThat(simuleringsresultatDto.perioder).isEmpty()
-        assertThat(simuleringsresultatDto.etterbetaling).isZero
-        assertThat(simuleringsresultatDto.feilutbetaling).isZero
+        assertThat(simuleringsoppsummering.perioder).isEmpty()
+        assertThat(simuleringsoppsummering.etterbetaling).isZero
+        assertThat(simuleringsoppsummering.feilutbetaling).isZero
     }
 
     @Test
@@ -40,12 +42,12 @@ internal class SimuleringUtilTest {
         val posteringer =
                 posteringer(januar(2020), posteringstype = YTELSE, antallMåneder = 36, beløp = 5_000)
 
-        val simuleringsresultatDto =
+        val simuleringsoppsummering =
                 lagSimuleringsoppsummering(
                         posteringer.tilDetaljertSimuleringsresultat(),
                         1.januar(2021))
 
-        val posteringerGruppert = simuleringsresultatDto.perioder
+        val posteringerGruppert = simuleringsoppsummering.perioder
         assertThat(posteringerGruppert).hasSize(36)
         assertThat(posteringerGruppert.sumOf { it.feilutbetaling }).isZero
         assertThat(posteringerGruppert.sumOf { it.resultat.toInt() }).isEqualTo(5000 * 36)
@@ -53,10 +55,10 @@ internal class SimuleringUtilTest {
         assertThat(posteringerGruppert.last().nyttBeløp.toInt()).isEqualTo(5000)
         assertThat(posteringerGruppert.first().fom).isEqualTo(1.januar(2020))
         assertThat(posteringerGruppert.last().fom).isEqualTo(1.januar(2020).plusMonths(35))
-        assertThat(simuleringsresultatDto.etterbetaling.toInt()).isEqualTo(5000 * 12)
-        assertThat(simuleringsresultatDto.feilutbetaling).isZero
-        assertThat(simuleringsresultatDto.fom).isEqualTo(1.januar(2020))
-        assertThat(simuleringsresultatDto.forfallsdatoNestePeriode).isEqualTo(januar(2021).atEndOfMonth())
+        assertThat(simuleringsoppsummering.etterbetaling.toInt()).isEqualTo(5000 * 12)
+        assertThat(simuleringsoppsummering.feilutbetaling).isZero
+        assertThat(simuleringsoppsummering.fom).isEqualTo(1.januar(2020))
+        assertThat(simuleringsoppsummering.forfallsdatoNestePeriode).isEqualTo(januar(2021).atEndOfMonth())
     }
 
     @Test
@@ -68,12 +70,12 @@ internal class SimuleringUtilTest {
                 posteringer(juli(2020), posteringstype = YTELSE, antallMåneder = 7, beløp = 3000) +
                 posteringer(juli(2020), posteringstype = YTELSE, antallMåneder = 6, beløp = 2000)
 
-        val simuleringsresultatDto =
+        val simuleringsoppsummering =
                 lagSimuleringsoppsummering(
                        posteringer.tilDetaljertSimuleringsresultat(),
                        1.januar(2021))
 
-        val posteringerGruppert = simuleringsresultatDto.perioder
+        val posteringerGruppert = simuleringsoppsummering.perioder
 
         assertThat(posteringerGruppert.size).isEqualTo(13)
         assertThat(posteringerGruppert.sumOf { it.feilutbetaling.toInt() }).isEqualTo(2_000 * 6)
@@ -83,10 +85,10 @@ internal class SimuleringUtilTest {
         assertThat(posteringerGruppert.last().nyttBeløp.toInt()).isEqualTo(3_000)
         assertThat(posteringerGruppert.first().fom).isEqualTo(1.januar(2020))
         assertThat(posteringerGruppert.last().fom).isEqualTo(1.januar(2021))
-        assertThat(simuleringsresultatDto.etterbetaling.toInt()).isEqualTo(5_000 * 6)
-        assertThat(simuleringsresultatDto.feilutbetaling.toInt()).isEqualTo(2_000 * 6)
-        assertThat(simuleringsresultatDto.fom).isEqualTo(1.januar(2020))
-        assertThat(simuleringsresultatDto.forfallsdatoNestePeriode).isEqualTo(januar(2021).atEndOfMonth())
+        assertThat(simuleringsoppsummering.etterbetaling.toInt()).isEqualTo(5_000 * 6)
+        assertThat(simuleringsoppsummering.feilutbetaling.toInt()).isEqualTo(2_000 * 6)
+        assertThat(simuleringsoppsummering.fom).isEqualTo(1.januar(2020))
+        assertThat(simuleringsoppsummering.forfallsdatoNestePeriode).isEqualTo(januar(2021).atEndOfMonth())
     }
 
     @Test
@@ -209,22 +211,5 @@ internal class SimuleringUtilTest {
         Assertions.assertEquals(BigDecimal.valueOf(0), restSimulering.etterbetaling)
         Assertions.assertEquals(BigDecimal.valueOf(500), restSimulering.feilutbetaling)
     }
-
-    fun Int.januar(år: Int) = LocalDate.of(år, 1, this)
-    fun Int.august(år: Int) = LocalDate.of(år, 8, this)
-    fun januar(år: Int) = YearMonth.of(år, 1)
-    fun februar(år: Int) = YearMonth.of(år, 2)
-    fun juli(år: Int) = YearMonth.of(år, 7)
-
-    fun List<SimulertPostering>.tilSimuleringsperioder() =
-            grupperPosteringerEtterDato(this.tilSimuleringMottakere())
-
-    fun List<SimulertPostering>.tilSimuleringMottakere() =
-            listOf(SimuleringMottaker(this, randomFnr(), MottakerType.BRUKER))
-
-    fun List<SimulertPostering>.tilDetaljertSimuleringsresultat() =
-            DetaljertSimuleringResultat(this.tilSimuleringMottakere())
-
-    fun randomFnr(): String = "12345678901"
 
 }

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringUtilTest.kt
@@ -153,26 +153,6 @@ internal class SimuleringUtilTest {
         Assertions.assertEquals(BigDecimal.valueOf(-196), simuleringsperioder[0].resultat)
     }
 
-    @Ignore
-    fun `Test 'nytt beløp', 'tidligere utbetalt' og 'resultat' for simuleringsperiode med reduksjon i feilutbetaling`() {
-        val posteringer =
-                posteringer(juli(2021), beløp = 100, posteringstype = YTELSE) +
-                posteringer(juli(2021), beløp = 100, posteringstype = YTELSE) +
-                posteringer(juli(2021), beløp = -99, posteringstype = YTELSE) +
-                posteringer(juli(2021), beløp = -99, posteringstype = YTELSE) +
-                posteringer(juli(2021), beløp = 98, posteringstype = FEILUTBETALING) +
-                posteringer(juli(2021), beløp = -99, posteringstype = FEILUTBETALING)
-
-        val simuleringsperioder = grupperPosteringerEtterDato(
-                posteringer.tilSimuleringMottakere())
-
-        Assertions.assertEquals(1, simuleringsperioder.size)
-
-        Assertions.assertEquals(BigDecimal.valueOf(200), simuleringsperioder[0].nyttBeløp)
-        Assertions.assertEquals(BigDecimal.valueOf(197), simuleringsperioder[0].tidligereUtbetalt)
-        Assertions.assertEquals(BigDecimal.valueOf(1), simuleringsperioder[0].resultat)
-    }
-
     val simulertePosteringerMedNegativFeilutbetaling =
             posteringer(juli(2021), beløp = -500, posteringstype = FEILUTBETALING) +
             posteringer(juli(2021), beløp = -2000, posteringstype = YTELSE) +

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringUtilTest.kt
@@ -4,126 +4,227 @@ import no.nav.familie.ef.iverksett.posteringer
 import no.nav.familie.kontrakter.felles.simulering.DetaljertSimuleringResultat
 import no.nav.familie.kontrakter.felles.simulering.MottakerType
 import no.nav.familie.kontrakter.felles.simulering.PosteringType
+import no.nav.familie.kontrakter.felles.simulering.PosteringType.FEILUTBETALING
+import no.nav.familie.kontrakter.felles.simulering.PosteringType.YTELSE
 import no.nav.familie.kontrakter.felles.simulering.SimuleringMottaker
+import no.nav.familie.kontrakter.felles.simulering.SimulertPostering
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDate
-import java.time.temporal.TemporalAdjusters
+import java.time.YearMonth
 
 internal class SimuleringUtilTest {
 
     @Test
     internal fun `skal ikke mappe simuleringsdata for forskuddskatt, motp, justering og trekk `() {
-        val fraDato = LocalDate.of(2020, 1, 1)
-        val simuleringsmottakere = listOf(SimuleringMottaker(
-                simulertPostering = posteringer(fraDato, posteringstype = PosteringType.MOTP)
-                                    + posteringer(fraDato, posteringstype = PosteringType.FORSKUDSSKATT)
-                                    + posteringer(fraDato, posteringstype = PosteringType.JUSTERING)
-                                    + posteringer(fraDato, posteringstype = PosteringType.TREKK),
-                mottakerNummer = "12345678901",
-                mottakerType = MottakerType.BRUKER
-        ))
 
-        val simuleringsresultatDto =
-                lagSimuleringsoppsummering(DetaljertSimuleringResultat(simuleringsmottakere), fraDato.plusMonths(12))
+        val posteringer =
+                posteringer(januar(2020), posteringstype = PosteringType.MOTP) +
+                posteringer(januar(2020), posteringstype = PosteringType.FORSKUDSSKATT)+
+                posteringer(januar(2020), posteringstype = PosteringType.JUSTERING)+
+                posteringer(januar(2020), posteringstype = PosteringType.TREKK)
+
+        val simuleringsresultatDto = lagSimuleringsoppsummering(
+                posteringer.tilDetaljertSimuleringsresultat(),
+                1.januar(2021))
 
         assertThat(simuleringsresultatDto.perioder).isEmpty()
-        assertThat(simuleringsresultatDto.etterbetaling).isZero()
-        assertThat(simuleringsresultatDto.feilutbetaling).isZero()
+        assertThat(simuleringsresultatDto.etterbetaling).isZero
+        assertThat(simuleringsresultatDto.feilutbetaling).isZero
     }
 
     @Test
     internal fun `skal mappe simuleringsdata for enkel ytelse`() {
-        val fraDato = LocalDate.of(2020, 1, 1)
-        val beløp = BigDecimal(5000)
-        val antallMåneder = 36
-        val simuleringsmottakere = listOf(SimuleringMottaker(
-                simulertPostering = posteringer(fraDato,
-                                                posteringstype = PosteringType.YTELSE,
-                                                antallMåneder = antallMåneder,
-                                                beløp = beløp),
-                mottakerNummer = "12345678901",
-                mottakerType = MottakerType.BRUKER
-        ))
+        val posteringer =
+                posteringer(januar(2020), posteringstype = YTELSE, antallMåneder = 36, beløp = 5_000)
 
-        val antallMånederEtterStart: Long = 12
-        val tidSimuleringHentet = fraDato.plusMonths(antallMånederEtterStart)
         val simuleringsresultatDto =
-                lagSimuleringsoppsummering(DetaljertSimuleringResultat(simuleringsmottakere), tidSimuleringHentet)
+                lagSimuleringsoppsummering(
+                        posteringer.tilDetaljertSimuleringsresultat(),
+                        1.januar(2021))
 
         val posteringerGruppert = simuleringsresultatDto.perioder
-        assertThat(posteringerGruppert).hasSize(antallMåneder)
+        assertThat(posteringerGruppert).hasSize(36)
         assertThat(posteringerGruppert.sumOf { it.feilutbetaling }).isZero
-        assertThat(posteringerGruppert.sumOf { it.resultat }).isEqualTo(beløp.multiply(BigDecimal(antallMåneder)))
-        assertThat(posteringerGruppert.first().nyttBeløp).isEqualTo(beløp)
-        assertThat(posteringerGruppert.last().nyttBeløp).isEqualTo(beløp)
-        assertThat(posteringerGruppert.first().fom).isEqualTo(fraDato)
-        assertThat(posteringerGruppert.last().fom).isEqualTo(fraDato.plusMonths(antallMåneder.toLong() - 1))
-        assertThat(simuleringsresultatDto.etterbetaling).isEqualTo(beløp.multiply(antallMånederEtterStart.toBigDecimal()))
+        assertThat(posteringerGruppert.sumOf { it.resultat.toInt() }).isEqualTo(5000 * 36)
+        assertThat(posteringerGruppert.first().nyttBeløp.toInt()).isEqualTo(5000)
+        assertThat(posteringerGruppert.last().nyttBeløp.toInt()).isEqualTo(5000)
+        assertThat(posteringerGruppert.first().fom).isEqualTo(1.januar(2020))
+        assertThat(posteringerGruppert.last().fom).isEqualTo(1.januar(2020).plusMonths(35))
+        assertThat(simuleringsresultatDto.etterbetaling.toInt()).isEqualTo(5000 * 12)
         assertThat(simuleringsresultatDto.feilutbetaling).isZero
-        assertThat(simuleringsresultatDto.fom).isEqualTo(fraDato)
-        assertThat(simuleringsresultatDto.forfallsdatoNestePeriode).isEqualTo(tidSimuleringHentet.with(TemporalAdjusters.lastDayOfMonth()))
+        assertThat(simuleringsresultatDto.fom).isEqualTo(1.januar(2020))
+        assertThat(simuleringsresultatDto.forfallsdatoNestePeriode).isEqualTo(januar(2021).atEndOfMonth())
     }
-
 
     @Test
     internal fun `skal mappe simuleringsdata for ytelse hvor bruker har fått for mye i 6 måneder`() {
-        val fraDato = LocalDate.of(2020, 1, 1)
-        val antallMåneder = 12
-        val antallMånederFeilutbetalt = 6
-        val fraDatoFeilutbetalt = fraDato.plusMonths(antallMånederFeilutbetalt.toLong())
-        val beløp = BigDecimal(5000)
-        val nyttBeløp = BigDecimal(3000)
-        val simuleringsmottakere = listOf(SimuleringMottaker(
-                simulertPostering = posteringer(fraDato,
-                                                posteringstype = PosteringType.YTELSE,
-                                                antallMåneder = antallMåneder - antallMånederFeilutbetalt,
-                                                beløp = beløp)
-                                    + posteringer(fraDatoFeilutbetalt,
-                                                  posteringstype = PosteringType.FEILUTBETALING,
-                                                  antallMåneder = antallMånederFeilutbetalt,
-                                                  beløp = beløp.minus(nyttBeløp))
-                                    + posteringer(fraDatoFeilutbetalt,
-                                                  posteringstype = PosteringType.YTELSE,
-                                                  antallMåneder = antallMånederFeilutbetalt,
-                                                  beløp = beløp.negate())
-                                    + posteringer(fraDatoFeilutbetalt,
-                                                  posteringstype = PosteringType.YTELSE,
-                                                  antallMåneder = antallMånederFeilutbetalt + 1,
-                                                  beløp = nyttBeløp)
-                                    + posteringer(fraDatoFeilutbetalt,
-                                                  posteringstype = PosteringType.YTELSE,
-                                                  antallMåneder = antallMånederFeilutbetalt,
-                                                  beløp = beløp.minus(nyttBeløp)),
-                mottakerNummer = "12345678901",
-                mottakerType = MottakerType.BRUKER
-        ))
+        val posteringer =
+                posteringer(januar(2020), posteringstype = YTELSE, antallMåneder = 6, beløp = 5_000) +
+                posteringer(juli(2020), posteringstype = FEILUTBETALING, antallMåneder = 6, beløp = 2_000) +
+                posteringer(juli(2020), posteringstype = YTELSE, antallMåneder = 6, beløp = -5000) +
+                posteringer(juli(2020), posteringstype = YTELSE, antallMåneder = 7, beløp = 3000) +
+                posteringer(juli(2020), posteringstype = YTELSE, antallMåneder = 6, beløp = 2000)
 
-        val antallMånederEtterStart: Long = 12
-        val tidSimuleringHentet = fraDato.plusMonths(antallMånederEtterStart)
         val simuleringsresultatDto =
-                lagSimuleringsoppsummering(DetaljertSimuleringResultat(simuleringsmottakere), tidSimuleringHentet)
+                lagSimuleringsoppsummering(
+                       posteringer.tilDetaljertSimuleringsresultat(),
+                       1.januar(2021))
 
         val posteringerGruppert = simuleringsresultatDto.perioder
-        val totaltFeilutbetaltBeløp = beløp.minus(nyttBeløp).multiply(BigDecimal(antallMånederFeilutbetalt))
 
-        assertThat(posteringerGruppert).hasSize(antallMåneder + 1)
-        assertThat(posteringerGruppert.sumOf { it.feilutbetaling }).isEqualTo(totaltFeilutbetaltBeløp)
-        assertThat(posteringerGruppert.sumOf { it.nyttBeløp }).isEqualTo(nyttBeløp.plus(beløp.multiply(BigDecimal(antallMåneder))
-                                                                                                .minus(
-                                                                                                        totaltFeilutbetaltBeløp)))
-        assertThat(posteringerGruppert.sumOf { it.resultat }).isEqualTo(nyttBeløp.plus(
-                beløp.multiply(BigDecimal(antallMåneder - antallMånederFeilutbetalt)).minus(totaltFeilutbetaltBeløp))
-        )
-        assertThat(posteringerGruppert.first().nyttBeløp).isEqualTo(beløp)
-        assertThat(posteringerGruppert.last().nyttBeløp).isEqualTo(nyttBeløp)
-        assertThat(posteringerGruppert.first().fom).isEqualTo(fraDato)
-        assertThat(posteringerGruppert.last().fom).isEqualTo(fraDato.plusMonths(antallMåneder.toLong()))
-        assertThat(simuleringsresultatDto.etterbetaling).isEqualTo(beløp.multiply(BigDecimal(antallMånederEtterStart - antallMånederFeilutbetalt)))
-        assertThat(simuleringsresultatDto.feilutbetaling).isEqualTo(totaltFeilutbetaltBeløp)
-        assertThat(simuleringsresultatDto.fom).isEqualTo(fraDato)
-        assertThat(simuleringsresultatDto.forfallsdatoNestePeriode).isEqualTo(tidSimuleringHentet.with(TemporalAdjusters.lastDayOfMonth()))
+        assertThat(posteringerGruppert.size).isEqualTo(13)
+        assertThat(posteringerGruppert.sumOf { it.feilutbetaling.toInt() }).isEqualTo(2_000 * 6)
+        assertThat(posteringerGruppert.sumOf { it.nyttBeløp.toInt() }).isEqualTo(3000 + 5_000 * 12 - 2_000 * 6)
+        assertThat(posteringerGruppert.sumOf { it.resultat.toInt() }).isEqualTo(3000 + 5_000 * 6 - 2_000 * 6)
+        assertThat(posteringerGruppert.first().nyttBeløp.toInt()).isEqualTo(5_000)
+        assertThat(posteringerGruppert.last().nyttBeløp.toInt()).isEqualTo(3_000)
+        assertThat(posteringerGruppert.first().fom).isEqualTo(1.januar(2020))
+        assertThat(posteringerGruppert.last().fom).isEqualTo(1.januar(2021))
+        assertThat(simuleringsresultatDto.etterbetaling.toInt()).isEqualTo(5_000 * 6)
+        assertThat(simuleringsresultatDto.feilutbetaling.toInt()).isEqualTo(2_000 * 6)
+        assertThat(simuleringsresultatDto.fom).isEqualTo(1.januar(2020))
+        assertThat(simuleringsresultatDto.forfallsdatoNestePeriode).isEqualTo(januar(2021).atEndOfMonth())
     }
+
+    @Test
+    fun `skal lage tom liste av simuleringsperioder`() {
+        assertThat(emptyList<SimulertPostering>().tilSimuleringsperioder())
+                .isEmpty()
+    }
+
+    @Test
+    fun `skal gruppere og sortere på fom-dato`() {
+
+        val simuleringsperioder =
+                (posteringer(januar(2021), 2, 3_000, YTELSE) +
+                 posteringer(januar(2021), 3, 5_000, YTELSE) +
+                 posteringer(februar(2021), 3, 2_000, YTELSE)
+                ).tilSimuleringsperioder()
+
+        assertThat(simuleringsperioder.size).isEqualTo(4)
+        assertThat(simuleringsperioder[0].nyttBeløp.toInt()).isEqualTo(8_000)
+        assertThat(simuleringsperioder[1].nyttBeløp.toInt()).isEqualTo(10_000)
+        assertThat(simuleringsperioder[2].nyttBeløp.toInt()).isEqualTo(7_000)
+        assertThat(simuleringsperioder[3].nyttBeløp.toInt()).isEqualTo(2_000)
+    }
+
+    @Test
+    fun `Test henting av 'nytt beløp ', 'tidligere utbetalt ' og 'resultat ' for simuleringsperiode uten feilutbetaling`() {
+        val posteringer =
+                posteringer(juli(2021), beløp = 100, posteringstype = YTELSE) +
+                posteringer(juli(2021), beløp = 100, posteringstype = YTELSE) +
+                posteringer(juli(2021), beløp = -99, posteringstype = YTELSE) +
+                posteringer(juli(2021), beløp = -99, posteringstype = YTELSE)
+
+        val simuleringsperioder = grupperPosteringerEtterDato(
+                posteringer.tilSimuleringMottakere())
+
+        Assertions.assertEquals(1, simuleringsperioder.size)
+        Assertions.assertEquals(BigDecimal.valueOf(200), simuleringsperioder[0].nyttBeløp)
+        Assertions.assertEquals(BigDecimal.valueOf(198), simuleringsperioder[0].tidligereUtbetalt)
+        Assertions.assertEquals(BigDecimal.valueOf(2), simuleringsperioder[0].resultat)
+    }
+
+    @Test
+    fun `Test henting av 'nytt beløp', 'tidligere utbetalt' og 'resultat' for simuleringsperiode med feilutbetaling`() {
+        val posteringer =
+                posteringer(juli(2021), beløp = 100, posteringstype = YTELSE) +
+                posteringer(juli(2021), beløp = 100, posteringstype = YTELSE) +
+                posteringer(juli(2021), beløp = -99, posteringstype = YTELSE) +
+                posteringer(juli(2021), beløp = -99, posteringstype = YTELSE) +
+                posteringer(juli(2021), beløp = 98, posteringstype = FEILUTBETALING) +
+                posteringer(juli(2021), beløp = 98, posteringstype = FEILUTBETALING)
+
+        val simuleringsperioder = grupperPosteringerEtterDato(
+                posteringer.tilSimuleringMottakere())
+
+        Assertions.assertEquals(1, simuleringsperioder.size)
+        Assertions.assertEquals(BigDecimal.valueOf(4), simuleringsperioder[0].nyttBeløp)
+        Assertions.assertEquals(BigDecimal.valueOf(198), simuleringsperioder[0].tidligereUtbetalt)
+        Assertions.assertEquals(BigDecimal.valueOf(-196), simuleringsperioder[0].resultat)
+    }
+
+    @Test
+    fun `Test 'nytt beløp', 'tidligere utbetalt' og 'resultat' for simuleringsperiode med reduksjon i feilutbetaling`() {
+        val posteringer =
+                posteringer(juli(2021), beløp = 100, posteringstype = YTELSE) +
+                posteringer(juli(2021), beløp = 100, posteringstype = YTELSE) +
+                posteringer(juli(2021), beløp = -99, posteringstype = YTELSE) +
+                posteringer(juli(2021), beløp = -99, posteringstype = YTELSE) +
+                posteringer(juli(2021), beløp = 98, posteringstype = FEILUTBETALING) +
+                posteringer(juli(2021), beløp = -99, posteringstype = FEILUTBETALING)
+
+        val simuleringsperioder = grupperPosteringerEtterDato(
+                posteringer.tilSimuleringMottakere())
+
+        Assertions.assertEquals(1, simuleringsperioder.size)
+
+        Assertions.assertEquals(BigDecimal.valueOf(200), simuleringsperioder[0].nyttBeløp)
+        Assertions.assertEquals(BigDecimal.valueOf(197), simuleringsperioder[0].tidligereUtbetalt)
+        Assertions.assertEquals(BigDecimal.valueOf(1), simuleringsperioder[0].resultat)
+    }
+
+    val simulertePosteringerMedNegativFeilutbetaling =
+            posteringer(juli(2021), beløp = -500, posteringstype = FEILUTBETALING) +
+            posteringer(juli(2021), beløp = -2000, posteringstype = YTELSE) +
+            posteringer(juli(2021), beløp = 3000, posteringstype = YTELSE) +
+            posteringer(juli(2021), beløp = -500, posteringstype = YTELSE)
+
+    @Test
+    fun `Total etterbetaling skal bli summen av ytelsene i periode med negativ feilutbetaling`() {
+        val restSimulering = lagSimuleringsoppsummering(
+                simulertePosteringerMedNegativFeilutbetaling.tilDetaljertSimuleringsresultat(),
+                15.august(2021)
+        )
+
+        Assertions.assertEquals(BigDecimal.valueOf(500), restSimulering.etterbetaling)
+    }
+
+    @Test
+    fun `Total feilutbetaling skal bli 0 i periode med negativ feilutbetaling`() {
+        val restSimulering = lagSimuleringsoppsummering(
+                simulertePosteringerMedNegativFeilutbetaling.tilDetaljertSimuleringsresultat(),
+                15.august(2021)
+        )
+
+        Assertions.assertEquals(BigDecimal.valueOf(0), restSimulering.feilutbetaling)
+    }
+
+    @Test
+    fun `Skal gi 0 etterbetaling og sum feilutbetaling ved positiv feilutbetaling`() {
+        val posteringer =
+                posteringer(juli(2021), beløp = 500, posteringstype = FEILUTBETALING) +
+                posteringer(juli(2021), beløp = -2000, posteringstype = YTELSE) +
+                posteringer(juli(2021), beløp = 3000, posteringstype = YTELSE) +
+                posteringer(juli(2021), beløp = -500, posteringstype = YTELSE)
+
+        val restSimulering = lagSimuleringsoppsummering(
+                posteringer.tilDetaljertSimuleringsresultat(),
+                15.august(2021)
+        )
+
+        Assertions.assertEquals(BigDecimal.valueOf(0), restSimulering.etterbetaling)
+        Assertions.assertEquals(BigDecimal.valueOf(500), restSimulering.feilutbetaling)
+    }
+
+    fun Int.januar(år: Int) = LocalDate.of(år, 1, this)
+    fun Int.august(år: Int) = LocalDate.of(år, 8, this)
+    fun januar(år: Int) = YearMonth.of(år, 1)
+    fun februar(år: Int) = YearMonth.of(år, 2)
+    fun juli(år: Int) = YearMonth.of(år, 7)
+
+    fun List<SimulertPostering>.tilSimuleringsperioder() =
+            grupperPosteringerEtterDato(this.tilSimuleringMottakere())
+
+    fun List<SimulertPostering>.tilSimuleringMottakere() =
+            listOf(SimuleringMottaker(this, randomFnr(), MottakerType.BRUKER))
+
+    fun List<SimulertPostering>.tilDetaljertSimuleringsresultat() =
+            DetaljertSimuleringResultat(this.tilSimuleringMottakere())
+
+    fun randomFnr(): String = "12345678901"
 
 }

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/SimuleringUtilTest.kt
@@ -196,6 +196,13 @@ internal class SimuleringUtilTest {
         Assertions.assertEquals(BigDecimal.valueOf(500), restSimulering.feilutbetaling)
     }
 
+    /*
+        De neste testene antar at brukeren går gjennom følgende for ÉN periode:
+        - Førstegangsbehandling gir ytelse på kr 10 000
+        - Revurdering reduserer ytelse fra kr 10 000 til kr 2 000, dvs kr 8 000 feilutbetalt
+        - Revurdering øker ytelse fra kr 2 000 til kr 3 000, dvs feilutbetaling reduseres
+        - Revurdering øker ytelse fra kr 3 000 tik kr 12 000, dvs feilutbetaling nulles ut, og etterbetaling skjer
+     */
     @Test
     fun `ytelse på 10000 korrigert til 2000`() {
 
@@ -240,7 +247,7 @@ internal class SimuleringUtilTest {
     }
 
     @Test
-    fun test() {
+    fun `ytelse på 3000 korrigert til 12000`() {
 
         val øktYtelseFra3_000Til12_000 =
                 posteringer(beløp = -3_000, posteringstype = YTELSE, betalingstype = KREDIT) +


### PR DESCRIPTION
Denne PRen gjør endrinfer i `lagSimuleringsoppsummering` hentet fra ba-sak, inkludert tester. Forhåpentligvis blir simuleringsoppsummeringen bedre av dette.

ba-sak har `Simuleringsperiode.etterbetaling`. For ikke å gjøre endringer i protokollen, blir den verdien bare brukt midlertidig  for å beregne etterbetaling i simuleringsoppsummeringen. 