### PR TITLE
Setter eksplisitt eksternReferanseId for å unngå duplikat då vi sende…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/JournalførVedtaksbrevTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/JournalførVedtaksbrevTask.kt
@@ -48,6 +48,7 @@ class JournalførVedtaksbrevTask(private val iverksettingRepository: Iverksettin
                         hoveddokumentvarianter = listOf(dokument),
                         fagsakId = iverksett.fagsak.eksternId.toString(),
                         journalførendeEnhet = iverksett.søker.tilhørendeEnhet,
+                        eksternReferanseId = "$behandlingId-vedtaksbrev"
                 ),
                 iverksett.vedtak.beslutterId
         ).journalpostId


### PR DESCRIPTION
…r flere vedlegg fra samme callId som ellers blir brukt

Integrasjoner setter denne automatiskt til callId hvis den mangler. Vi sender allerede en ArkiverDokumentRequest for vedtak så då blir det duplikat.

https://nav-it.slack.com/archives/CJN0STWB0/p1638883574124300

https://github.com/navikt/familie-ef-sak/pull/1036