### PR TITLE
Forenkling av Utbetalingsgenerator

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ef.iverksett.økonomi.utbetalingsoppdrag.ØkonomiUtils.and
 import no.nav.familie.ef.iverksett.økonomi.utbetalingsoppdrag.ØkonomiUtils.andelerTilOpprettelse
 import no.nav.familie.ef.iverksett.økonomi.utbetalingsoppdrag.ØkonomiUtils.andelerUtenNullVerdier
 import no.nav.familie.ef.iverksett.økonomi.utbetalingsoppdrag.ØkonomiUtils.beståendeAndeler
+import no.nav.familie.ef.iverksett.økonomi.utbetalingsoppdrag.ØkonomiUtils.utbetalingsperiodeForOpphør
 import no.nav.familie.ef.iverksett.økonomi.utbetalingsoppdrag.ØkonomiUtils.validerOpphørsdato
 import no.nav.familie.kontrakter.ef.felles.StønadType
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
@@ -73,18 +74,11 @@ object UtbetalingsoppdragGenerator {
     private fun opphørsperioder(forrigeTilkjentYtelse: TilkjentYtelse?,
                                 nyTilkjentYtelseMedMetaData: TilkjentYtelseMedMetaData): List<Utbetalingsperiode> {
         val andelerForrigeTilkjentYtelse = andelerUtenNullVerdier(forrigeTilkjentYtelse)
-        val nyTilkjentYtelse = nyTilkjentYtelseMedMetaData.tilkjentYtelse
 
-        val andelTilOpphørMedDato = andelTilOpphørMedDato(andelerForrigeTilkjentYtelse,
-                                                          forrigeTilkjentYtelse?.startdato,
-                                                          nyTilkjentYtelse)
-
-        return andelTilOpphørMedDato?.let {
-            lagUtbetalingsperioderForOpphør(andeler = andelTilOpphørMedDato,
-                                            tilkjentYtelse = nyTilkjentYtelseMedMetaData,
-                                            behandlingId = nyTilkjentYtelseMedMetaData.eksternBehandlingId,
-                                            type = nyTilkjentYtelseMedMetaData.stønadstype)
-        } ?: emptyList()
+        val utbetalingsperiode = utbetalingsperiodeForOpphør(andelerForrigeTilkjentYtelse,
+                                                             forrigeTilkjentYtelse?.startdato,
+                                                             nyTilkjentYtelseMedMetaData)
+        return utbetalingsperiode?.let { listOf(it) } ?: emptyList()
     }
 
     private fun erIkkeTidligereIverksattMotOppdrag(forrigeTilkjentYtelse: TilkjentYtelse?) =
@@ -104,20 +98,6 @@ object UtbetalingsoppdragGenerator {
         return this.ifEmpty {
             listOf(nullAndelTilkjentYtelse(nyTilkjentYtelseMedMetaData.behandlingId, sistePeriodeIdIForrigeKjede))
         }
-    }
-
-    private fun lagUtbetalingsperioderForOpphør(andeler: Pair<AndelTilkjentYtelse, LocalDate>,
-                                                behandlingId: Long,
-                                                type: StønadType,
-                                                tilkjentYtelse: TilkjentYtelseMedMetaData): List<Utbetalingsperiode> {
-        val (sisteAndelIKjede, opphørKjedeFom) = andeler
-        return listOf(lagPeriodeFraAndel(andel = sisteAndelIKjede,
-                                         eksternBehandlingId = behandlingId,
-                                         type = type,
-                                         personIdent = tilkjentYtelse.personIdent,
-                                         vedtaksdato = tilkjentYtelse.vedtaksdato,
-                                         opphørKjedeFom = opphørKjedeFom,
-                                         erEndringPåEksisterendePeriode = true))
     }
 
     private fun lagUtbetalingsperioderForOpprettelse(andeler: List<AndelTilkjentYtelse>,

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -4,18 +4,15 @@ import no.nav.familie.ef.iverksett.iverksetting.domene.AndelTilkjentYtelse
 import no.nav.familie.ef.iverksett.iverksetting.domene.TilkjentYtelse
 import no.nav.familie.ef.iverksett.iverksetting.domene.TilkjentYtelseMedMetaData
 import no.nav.familie.ef.iverksett.util.tilKlassifisering
-import no.nav.familie.ef.iverksett.økonomi.utbetalingsoppdrag.ØkonomiUtils.andelTilOpphørMedDato
 import no.nav.familie.ef.iverksett.økonomi.utbetalingsoppdrag.ØkonomiUtils.andelerTilOpprettelse
 import no.nav.familie.ef.iverksett.økonomi.utbetalingsoppdrag.ØkonomiUtils.andelerUtenNullVerdier
 import no.nav.familie.ef.iverksett.økonomi.utbetalingsoppdrag.ØkonomiUtils.beståendeAndeler
 import no.nav.familie.ef.iverksett.økonomi.utbetalingsoppdrag.ØkonomiUtils.utbetalingsperiodeForOpphør
 import no.nav.familie.ef.iverksett.økonomi.utbetalingsoppdrag.ØkonomiUtils.validerOpphørsdato
-import no.nav.familie.kontrakter.ef.felles.StønadType
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag.KodeEndring.ENDR
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag.KodeEndring.NY
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
-import java.time.LocalDate
 import java.util.UUID
 
 object UtbetalingsoppdragGenerator {
@@ -39,16 +36,12 @@ object UtbetalingsoppdragGenerator {
         val beståendeAndeler = beståendeAndeler(andelerForrigeTilkjentYtelse, andelerNyTilkjentYtelse)
         val andelerTilOpprettelse = andelerTilOpprettelse(andelerNyTilkjentYtelse, beståendeAndeler)
 
-        val andelerTilOpprettelseMedPeriodeId =
-                lagAndelerMedPeriodeId(andelerTilOpprettelse,
-                                       sistePeriodeIdIForrigeKjede,
-                                       nyTilkjentYtelseMedMetaData.behandlingId)
+        val andelerTilOpprettelseMedPeriodeId = lagAndelerMedPeriodeId(andelerTilOpprettelse,
+                                                                       sistePeriodeIdIForrigeKjede,
+                                                                       nyTilkjentYtelseMedMetaData.behandlingId)
 
-        val utbetalingsperioderSomOpprettes =
-                lagUtbetalingsperioderForOpprettelse(andeler = andelerTilOpprettelseMedPeriodeId,
-                                                     eksternBehandlingId = nyTilkjentYtelseMedMetaData.eksternBehandlingId,
-                                                     tilkjentYtelse = nyTilkjentYtelseMedMetaData,
-                                                     type = nyTilkjentYtelseMedMetaData.stønadstype)
+        val utbetalingsperioderSomOpprettes = lagUtbetalingsperioderForOpprettelse(andeler = andelerTilOpprettelseMedPeriodeId,
+                                                                                   tilkjentYtelse = nyTilkjentYtelseMedMetaData)
 
         val utbetalingsperioderSomOpphøres = opphørsperioder(forrigeTilkjentYtelse, nyTilkjentYtelseMedMetaData)
 
@@ -101,13 +94,11 @@ object UtbetalingsoppdragGenerator {
     }
 
     private fun lagUtbetalingsperioderForOpprettelse(andeler: List<AndelTilkjentYtelse>,
-                                                     eksternBehandlingId: Long,
-                                                     type: StønadType,
                                                      tilkjentYtelse: TilkjentYtelseMedMetaData): List<Utbetalingsperiode> {
         return andeler.map {
             lagPeriodeFraAndel(andel = it,
-                               type = type,
-                               eksternBehandlingId = eksternBehandlingId,
+                               type = tilkjentYtelse.stønadstype,
+                               eksternBehandlingId = tilkjentYtelse.eksternBehandlingId,
                                vedtaksdato = tilkjentYtelse.vedtaksdato,
                                personIdent = tilkjentYtelse.personIdent)
         }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -36,9 +36,6 @@ object UtbetalingsoppdragGenerator {
         val sistePeriodeIdIForrigeKjede = sistePeriodeId(forrigeTilkjentYtelse)
 
         val beståendeAndeler = beståendeAndeler(andelerForrigeTilkjentYtelse, andelerNyTilkjentYtelse)
-        val andelTilOpphørMedDato = andelTilOpphørMedDato(andelerForrigeTilkjentYtelse,
-                                                          forrigeTilkjentYtelse?.startdato,
-                                                          nyTilkjentYtelse)
         val andelerTilOpprettelse = andelerTilOpprettelse(andelerNyTilkjentYtelse, beståendeAndeler)
 
         val andelerTilOpprettelseMedPeriodeId =
@@ -52,12 +49,7 @@ object UtbetalingsoppdragGenerator {
                                                      tilkjentYtelse = nyTilkjentYtelseMedMetaData,
                                                      type = nyTilkjentYtelseMedMetaData.stønadstype)
 
-        val utbetalingsperioderSomOpphøres = andelTilOpphørMedDato?.let {
-            lagUtbetalingsperioderForOpphør(andeler = andelTilOpphørMedDato,
-                                            tilkjentYtelse = nyTilkjentYtelseMedMetaData,
-                                            behandlingId = nyTilkjentYtelseMedMetaData.eksternBehandlingId,
-                                            type = nyTilkjentYtelseMedMetaData.stønadstype)
-        } ?: emptyList()
+        val utbetalingsperioderSomOpphøres = opphørsperioder(forrigeTilkjentYtelse, nyTilkjentYtelseMedMetaData)
 
         val utbetalingsperioder = listOf(utbetalingsperioderSomOpprettes, utbetalingsperioderSomOpphøres)
                 .flatten()
@@ -76,6 +68,23 @@ object UtbetalingsoppdragGenerator {
         return nyTilkjentYtelse.copy(utbetalingsoppdrag = utbetalingsoppdrag,
                                      andelerTilkjentYtelse = gjeldendeAndeler)
         //TODO legge til startperiode, sluttperiode, opphørsdato. Se i BA-sak - legges på i konsistensavstemming?
+    }
+
+    private fun opphørsperioder(forrigeTilkjentYtelse: TilkjentYtelse?,
+                                nyTilkjentYtelseMedMetaData: TilkjentYtelseMedMetaData): List<Utbetalingsperiode> {
+        val andelerForrigeTilkjentYtelse = andelerUtenNullVerdier(forrigeTilkjentYtelse)
+        val nyTilkjentYtelse = nyTilkjentYtelseMedMetaData.tilkjentYtelse
+
+        val andelTilOpphørMedDato = andelTilOpphørMedDato(andelerForrigeTilkjentYtelse,
+                                                          forrigeTilkjentYtelse?.startdato,
+                                                          nyTilkjentYtelse)
+
+        return andelTilOpphørMedDato?.let {
+            lagUtbetalingsperioderForOpphør(andeler = andelTilOpphørMedDato,
+                                            tilkjentYtelse = nyTilkjentYtelseMedMetaData,
+                                            behandlingId = nyTilkjentYtelseMedMetaData.eksternBehandlingId,
+                                            type = nyTilkjentYtelseMedMetaData.stønadstype)
+        } ?: emptyList()
     }
 
     private fun erIkkeTidligereIverksattMotOppdrag(forrigeTilkjentYtelse: TilkjentYtelse?) =

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -43,10 +43,10 @@ object UtbetalingsoppdragGenerator {
         val utbetalingsperioderSomOpprettes = lagUtbetalingsperioderForOpprettelse(andeler = andelerTilOpprettelseMedPeriodeId,
                                                                                    tilkjentYtelse = nyTilkjentYtelseMedMetaData)
 
-        val utbetalingsperioderSomOpphøres = opphørsperioder(forrigeTilkjentYtelse, nyTilkjentYtelseMedMetaData)
+        val utbetalingsperiodeSomOpphøres = utbetalingsperiodeForOpphør(forrigeTilkjentYtelse, nyTilkjentYtelseMedMetaData)
 
-        val utbetalingsperioder = listOf(utbetalingsperioderSomOpprettes, utbetalingsperioderSomOpphøres)
-                .flatten()
+        val utbetalingsperioder = (utbetalingsperioderSomOpprettes + utbetalingsperiodeSomOpphøres)
+                .filterNotNull()
                 .sortedBy { it.periodeId }
         val utbetalingsoppdrag =
                 Utbetalingsoppdrag(saksbehandlerId = nyTilkjentYtelseMedMetaData.saksbehandlerId,
@@ -62,16 +62,6 @@ object UtbetalingsoppdragGenerator {
         return nyTilkjentYtelse.copy(utbetalingsoppdrag = utbetalingsoppdrag,
                                      andelerTilkjentYtelse = gjeldendeAndeler)
         //TODO legge til startperiode, sluttperiode, opphørsdato. Se i BA-sak - legges på i konsistensavstemming?
-    }
-
-    private fun opphørsperioder(forrigeTilkjentYtelse: TilkjentYtelse?,
-                                nyTilkjentYtelseMedMetaData: TilkjentYtelseMedMetaData): List<Utbetalingsperiode> {
-        val andelerForrigeTilkjentYtelse = andelerUtenNullVerdier(forrigeTilkjentYtelse)
-
-        val utbetalingsperiode = utbetalingsperiodeForOpphør(andelerForrigeTilkjentYtelse,
-                                                             forrigeTilkjentYtelse?.startdato,
-                                                             nyTilkjentYtelseMedMetaData)
-        return utbetalingsperiode?.let { listOf(it) } ?: emptyList()
     }
 
     private fun erIkkeTidligereIverksattMotOppdrag(forrigeTilkjentYtelse: TilkjentYtelse?) =

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsperiodeMal.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsperiodeMal.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ef.iverksett.økonomi.utbetalingsoppdrag
 
 import no.nav.familie.ef.iverksett.iverksetting.domene.AndelTilkjentYtelse
-import no.nav.familie.ef.iverksett.iverksetting.domene.TilkjentYtelseMedMetaData
 import no.nav.familie.ef.iverksett.util.tilKlassifisering
 import no.nav.familie.kontrakter.ef.felles.StønadType
 import no.nav.familie.kontrakter.ef.iverksett.Periodetype
@@ -11,35 +10,13 @@ import java.math.BigDecimal
 import java.time.LocalDate
 
 /**
- * Lager mal for generering av utbetalingsperioder med tilpasset setting av verdier basert på parametre
+ * * Lager utbetalingsperioder som legges på utbetalingsoppdrag. En utbetalingsperiode tilsvarer linjer hos økonomi
  *
- * @param[vedtak] for vedtakdato og opphørsdato hvis satt
+ * @param[andel] andel som skal mappes til periode
+ * @param[opphørKjedeFom] fom-dato fra tidligste periode i kjede med endring
  * @param[erEndringPåEksisterendePeriode] ved true vil oppdrag sette asksjonskode ENDR på linje og ikke referere bakover
- * @return mal med tilpasset lagPeriodeFraAndel
+ * @return Periode til utbetalingsoppdrag
  */
-data class UtbetalingsperiodeMal(val tilkjentYtelse: TilkjentYtelseMedMetaData,
-                                 val erEndringPåEksisterendePeriode: Boolean = false) {
-
-    /**
-     * Lager utbetalingsperioder som legges på utbetalingsoppdrag. En utbetalingsperiode tilsvarer linjer hos økonomi
-     *
-     * @param[andel] andel som skal mappes til periode
-     * @param[opphørKjedeFom] fom-dato fra tidligste periode i kjede med endring
-     * @return Periode til utbetalingsoppdrag
-     */
-    fun lagPeriodeFraAndel(andel: AndelTilkjentYtelse,
-                           type: StønadType,
-                           behandlingId: Long,
-                           opphørKjedeFom: LocalDate? = null): Utbetalingsperiode =
-            lagPeriodeFraAndel(andel = andel,
-                               type = type,
-                               eksternBehandlingId = behandlingId,
-                               vedtaksdato = tilkjentYtelse.vedtaksdato,
-                               personIdent = tilkjentYtelse.personIdent,
-                               opphørKjedeFom = opphørKjedeFom,
-                               erEndringPåEksisterendePeriode = erEndringPåEksisterendePeriode)
-}
-
 fun lagPeriodeFraAndel(andel: AndelTilkjentYtelse,
                        type: StønadType,
                        eksternBehandlingId: Long,

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsperiodeMal.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsperiodeMal.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.iverksett.økonomi.utbetalingsoppdrag
 
 import no.nav.familie.ef.iverksett.iverksetting.domene.AndelTilkjentYtelse
+import no.nav.familie.ef.iverksett.iverksetting.domene.TilkjentYtelseMedMetaData
 import no.nav.familie.ef.iverksett.util.tilKlassifisering
 import no.nav.familie.kontrakter.ef.felles.StønadType
 import no.nav.familie.kontrakter.ef.iverksett.Periodetype
@@ -37,6 +38,18 @@ fun lagPeriodeFraAndel(andel: AndelTilkjentYtelse,
                            utbetalesTil = personIdent,
                            behandlingId = eksternBehandlingId,
                            utbetalingsgrad = andel.utbetalingsgrad())
+
+fun lagUtbetalingsperiodeForOpphør(sisteAndelIKjede: AndelTilkjentYtelse,
+                                   opphørKjedeFom: LocalDate,
+                                   tilkjentYtelse: TilkjentYtelseMedMetaData): Utbetalingsperiode {
+    return lagPeriodeFraAndel(andel = sisteAndelIKjede,
+                              eksternBehandlingId = tilkjentYtelse.eksternBehandlingId,
+                              type = tilkjentYtelse.stønadstype,
+                              personIdent = tilkjentYtelse.personIdent,
+                              vedtaksdato = tilkjentYtelse.vedtaksdato,
+                              opphørKjedeFom = opphørKjedeFom,
+                              erEndringPåEksisterendePeriode = true)
+}
 
 fun mapSatstype(periodetype: Periodetype) = when (periodetype) {
     Periodetype.MÅNED -> Utbetalingsperiode.SatsType.MND

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/ØkonomiUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/ØkonomiUtils.kt
@@ -75,7 +75,7 @@ object ØkonomiUtils {
     /**
      * Tar utgangspunkt i forrige tilstand og finner kjede med andeler til opphør og tilhørende opphørsdato
      *
-     * @param[andelerForrigeTilkjentYtelse] forrige behandlings tilstand
+     * @param[andelerForrigeTilkjentYtelse] forrige behandlings tilstand, uten andeler med 0-beløp
      * @param[andelerNyTilkjentYtelse] nåværende tilstand
      * @return siste andel og opphørsdato fra kjede med opphør, returnerer null hvis det ikke finnes ett opphørsdato
      */

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/ØkonomiUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/ØkonomiUtils.kt
@@ -80,12 +80,14 @@ object ØkonomiUtils {
      * @param[andelerNyTilkjentYtelse] nåværende tilstand
      * @return utbetalingsperiode for opphør, returnerer null hvis det ikke finnes ett opphørsdato
      */
-    fun utbetalingsperiodeForOpphør(andelerForrigeTilkjentYtelse: List<AndelTilkjentYtelse>,
-                                    forrigeOpphørsdato: LocalDate?,
+    fun utbetalingsperiodeForOpphør(forrigeTilkjentYtelse: TilkjentYtelse?,
                                     nyTilkjentYtelseMedMetaData: TilkjentYtelseMedMetaData): Utbetalingsperiode? {
-        val nyTilkjentYtelse = nyTilkjentYtelseMedMetaData.tilkjentYtelse
+        val forrigeOpphørsdato = forrigeTilkjentYtelse?.startdato
+        val andelerForrigeTilkjentYtelse = andelerUtenNullVerdier(forrigeTilkjentYtelse)
         val forrigeMaksDato = andelerForrigeTilkjentYtelse.map { it.tilOgMed }.maxOrNull()
         val forrigeAndeler = andelerForrigeTilkjentYtelse.toSet()
+
+        val nyTilkjentYtelse = nyTilkjentYtelseMedMetaData.tilkjentYtelse
         val oppdaterteAndeler = nyTilkjentYtelse.andelerTilkjentYtelse.toSet()
 
         val opphørsdato = beregnOpphørsdato(forrigeOpphørsdato, nyTilkjentYtelse.startdato, forrigeAndeler, oppdaterteAndeler)

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/ØkonomiUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/ØkonomiUtils.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.iverksett.iverksetting.domene.AndelTilkjentYtelse.Compa
 import no.nav.familie.ef.iverksett.iverksetting.domene.TilkjentYtelse
 import no.nav.familie.ef.iverksett.iverksetting.domene.TilkjentYtelseMedMetaData
 import no.nav.familie.kontrakter.ef.iverksett.Periodetype
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
 import java.time.LocalDate
 import java.util.UUID
 
@@ -77,11 +78,12 @@ object ØkonomiUtils {
      *
      * @param[andelerForrigeTilkjentYtelse] forrige behandlings tilstand, uten andeler med 0-beløp
      * @param[andelerNyTilkjentYtelse] nåværende tilstand
-     * @return siste andel og opphørsdato fra kjede med opphør, returnerer null hvis det ikke finnes ett opphørsdato
+     * @return utbetalingsperiode for opphør, returnerer null hvis det ikke finnes ett opphørsdato
      */
-    fun andelTilOpphørMedDato(andelerForrigeTilkjentYtelse: List<AndelTilkjentYtelse>,
-                              forrigeOpphørsdato: LocalDate?,
-                              nyTilkjentYtelse: TilkjentYtelse): Pair<AndelTilkjentYtelse, LocalDate>? {
+    fun utbetalingsperiodeForOpphør(andelerForrigeTilkjentYtelse: List<AndelTilkjentYtelse>,
+                                    forrigeOpphørsdato: LocalDate?,
+                                    nyTilkjentYtelseMedMetaData: TilkjentYtelseMedMetaData): Utbetalingsperiode? {
+        val nyTilkjentYtelse = nyTilkjentYtelseMedMetaData.tilkjentYtelse
         val forrigeMaksDato = andelerForrigeTilkjentYtelse.map { it.tilOgMed }.maxOrNull()
         val forrigeAndeler = andelerForrigeTilkjentYtelse.toSet()
         val oppdaterteAndeler = nyTilkjentYtelse.andelerTilkjentYtelse.toSet()
@@ -92,7 +94,7 @@ object ØkonomiUtils {
         return if (sisteForrigeAndel == null || opphørsdato == null || erNyPeriode(forrigeMaksDato, opphørsdato)) {
             null
         } else {
-            Pair(sisteForrigeAndel, opphørsdato)
+            lagUtbetalingsperiodeForOpphør(sisteForrigeAndel, opphørsdato, nyTilkjentYtelseMedMetaData)
         }
     }
 


### PR DESCRIPTION
Ønsker å gjøre noen forenklinger før jeg går videre for å støtte opphør på opphør

Har egentlige ikke gjort noen funksjonelle endringer.
Har flyttet kode koblet til opphørsperioder til utbetalingsperiodeForOpphør som nå oppretter en utbetalingsperiode i stedet for tidligere en andel, som sen ble mappet til en utbetalingsperiode.
Ønsker å gjøre dette for en idè om hvordan vi skal håndtere opphør på opphør.

Div forenklinger i koden, sjekk commits. 