### PR TITLE
Fjernet opphørsdato fra kontrakter, og startdato er required

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <prosessering.version>1.20220321101749_55e4576</prosessering.version>
         <changelist>-SNAPSHOT</changelist>
         <start-class>no.nav.familie.ef.iverksett.ApplicationKt</start-class>
-        <familie.kontrakter.version>2.0_20220329151411_82df2c6</familie.kontrakter.version>
+        <familie.kontrakter.version>2.0_20220331215756_9594442</familie.kontrakter.version>
         <familie.eksterne-kontrakter.stonadsstatistikk-ef>2.0_20220316102935_a849241</familie.eksterne-kontrakter.stonadsstatistikk-ef>
         <familie.eksterne-kontrakter.saksstatistikk-ef>2.0_20220107115927_4388dc5</familie.eksterne-kontrakter.saksstatistikk-ef>
         <token-validation-spring.version>2.0.14</token-validation-spring.version>

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/transformer/TilkjentYtelseDtoToDomain.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/transformer/TilkjentYtelseDtoToDomain.kt
@@ -8,7 +8,7 @@ import no.nav.familie.kontrakter.ef.iverksett.TilkjentYtelseMedMetadata as Tilkj
 fun TilkjentYtelseDto.toDomain(): TilkjentYtelse {
     return TilkjentYtelse(
             andelerTilkjentYtelse = this.andelerTilkjentYtelse.map { it.toDomain() },
-            startdato =this.startdato ?: this.opphørsdato)
+            startdato = this.startdato)
 }
 
 fun TilkjentYtelseMedMetadataDto.toDomain(): TilkjentYtelseMedMetaData {

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
@@ -28,7 +28,8 @@ import no.nav.familie.kontrakter.ef.iverksett.TilkjentYtelseMedMetadata as Tilkj
 fun simuleringDto(andeler: List<AndelTilkjentYtelseDto> = listOf(lagDefaultAndeler()), forrigeBehandlingId: UUID? = UUID.randomUUID()): SimuleringDto {
     val behandlingId = UUID.fromString("4b657902-d994-11eb-b8bc-0242ac130003")
     val tilkjentYtelseMedMetaData = TilkjentYtelseMedMetadataDto(
-            tilkjentYtelse = TilkjentYtelseDto(andelerTilkjentYtelse = andeler),
+            tilkjentYtelse = TilkjentYtelseDto(andelerTilkjentYtelse = andeler,
+                                               startdato = andeler.minOfOrNull { it.fraOgMed } ?: LocalDate.now()),
             saksbehandlerId = "saksbehandlerId",
             eksternBehandlingId = 1,
             stønadstype = StønadType.OVERGANGSSTØNAD,

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/util/IverksettMockUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/util/IverksettMockUtil.kt
@@ -70,7 +70,8 @@ fun opprettIverksettDto(behandlingId: UUID,
             kildeBehandlingId = UUID.randomUUID()
     )
     val tilkjentYtelse = TilkjentYtelseDto(
-            andelerTilkjentYtelse = listOf(andelTilkjentYtelse)
+            andelerTilkjentYtelse = listOf(andelTilkjentYtelse),
+            startdato = LocalDate.of(2020, 3, 1)
     )
 
     return IverksettDto(

--- a/src/test/resources/json/IverksettDtoEksempel.json
+++ b/src/test/resources/json/IverksettDtoEksempel.json
@@ -85,8 +85,7 @@
           "inntektsreduksjon": 0
         }
       ],
-      "opphørsdato": null,
-      "startdato": null
+      "startdato": "2020-03-01"
     },
     "tilbakekreving": {
       "tilbakekrevingsvalg": "OPPRETT_TILBAKEKREVING_MED_VARSEL",

--- a/src/test/resources/json/simulering_v1.json
+++ b/src/test/resources/json/simulering_v1.json
@@ -4,6 +4,7 @@
     "behandlingId": "234bed7c-b1d3-11eb-8529-0242ac130003",
     "vedtaksdato": "2021-07-23",
     "tilkjentYtelse": {
+      "startdato":  "2020-03-01",
       "andelerTilkjentYtelse": [
         {
           "utbetaltPerPeriode": 3800,


### PR DESCRIPTION
For å støtte endringene i kontrakter, men før endringen på startdato i domenet i iverksett endrer seg
https://github.com/navikt/familie-ef-iverksett/pull/388 

Koblet til:
* https://github.com/navikt/familie-kontrakter/pull/501
* https://github.com/navikt/familie-ef-sak/pull/1341