### PR TITLE
Ikke lag tilbakekrevingssak kun på nye oppl

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/OpprettTilbakekrevingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/OpprettTilbakekrevingTask.kt
@@ -47,10 +47,7 @@ class OpprettTilbakekrevingTask(private val iverksettingRepository: Iverksetting
             logger.warn("OpprettTilbakekrevingTask ikke utført - tilkjentYtelse er null, Behandling: $behandlingId")
             return
         } else if (iverksett.behandling.behandlingType == BehandlingType.FØRSTEGANGSBEHANDLING) {
-            logger.info("Førstegangsbehandling trenger ikke tilbakekreving behandlingId=$behandlingId")
-            return
-        } else if (iverksett.behandling.behandlingType == BehandlingType.FØRSTEGANGSBEHANDLING) {
-            logger.info("Førstegangsbehandling trenger ikke tilbakekreving behandlingId=$behandlingId")
+            logger.warn("Førstegangsbehandling trenger ikke tilbakekreving behandlingId=$behandlingId")
             return
         } else if (finnesÅpenTilbakekrevingsbehandling(iverksett)) {
             logger.info("Det finnnes allerede tilbakekrevingsbehandling for behandling=${behandlingId}")

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/OpprettTilbakekrevingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/OpprettTilbakekrevingTask.kt
@@ -39,27 +39,22 @@ class OpprettTilbakekrevingTask(private val iverksettingRepository: Iverksetting
     override fun doTask(task: Task) {
         val behandlingId = UUID.fromString(task.payload)
         val iverksett = iverksettingRepository.hent(behandlingId)
-        val nyIverksett = hentOppdatertIverksettHvisDetSkalLagesTilbakekreving(iverksett, behandlingId)
-        if(nyIverksett!= null) {
-            opprettTilbakekreving(behandlingId, nyIverksett)
-        }
 
-    }
-
-    private fun hentOppdatertIverksettHvisDetSkalLagesTilbakekreving(iverksett: Iverksett,
-                                                                     behandlingId: UUID?): Iverksett? {
         if (!iverksett.vedtak.tilbakekreving.skalTilbakekreves) {
-            logger.info("Tilbakekreving ikke valgt for behandlingId=$behandlingId. Oppretter ikke tilbakekrevingsbehandling.")
-            return null
+            logger.info("Tilbakekreving ikke valgt for behandlingId=$behandlingId. Oppretter derfor ikke tilbakekrevingsbehandling.")
+            return
         } else if (iverksett.vedtak.tilkjentYtelse == null) {
             logger.warn("OpprettTilbakekrevingTask ikke utført - tilkjentYtelse er null, Behandling: $behandlingId")
-            return null
+            return
         } else if (iverksett.behandling.behandlingType == BehandlingType.FØRSTEGANGSBEHANDLING) {
-            logger.error("Førstegangsbehandling trenger ikke tilbakekreving behandlingId=$behandlingId")
-            return null
+            logger.info("Førstegangsbehandling trenger ikke tilbakekreving behandlingId=$behandlingId")
+            return
+        } else if (iverksett.behandling.behandlingType == BehandlingType.FØRSTEGANGSBEHANDLING) {
+            logger.info("Førstegangsbehandling trenger ikke tilbakekreving behandlingId=$behandlingId")
+            return
         } else if (finnesÅpenTilbakekrevingsbehandling(iverksett)) {
             logger.info("Det finnnes allerede tilbakekrevingsbehandling for behandling=${behandlingId}")
-            return null
+            return
         }
 
         val nyBeriketSimuleringsresultat = hentBeriketSimulering(iverksett)
@@ -69,25 +64,20 @@ class OpprettTilbakekrevingTask(private val iverksettingRepository: Iverksetting
 
         if (!nyBeriketSimuleringsresultat.harFeilutbetaling()) {
             logger.info("Behandling=${behandlingId} har ikke (lenger) positiv feilutbetaling i simuleringen")
-            return null
+        }  else {
+            logger.info("Det kreves tilbakekrevingsbehandling for behandling=${behandlingId}")
+            val opprettTilbakekrevingRequest = lagTilbakekrevingRequest(nyIverksett)
+            tilbakekrevingClient.opprettBehandling(opprettTilbakekrevingRequest)
+            tilstandRepository.oppdaterTilbakekrevingResultat(
+                    behandlingId = behandlingId,
+                    TilbakekrevingResultat(opprettTilbakekrevingRequest))
+
+            // Burde iverksett oppdateres i DBen, siden tilbakekreving potensielt er endret?
+            // iverksettingRepository.lagreIverksett(behandlingId,nyIverksett)
+            logger.info("Opprettet tilbakekrevingsbehandling for behandling=${behandlingId}")
         }
-
-        return nyIverksett
     }
 
-    private fun opprettTilbakekreving(behandlingId: UUID,
-                                      nyIverksett: Iverksett) {
-        logger.info("Det kreves tilbakekrevingsbehandling for behandling=${behandlingId}")
-        val opprettTilbakekrevingRequest = lagTilbakekrevingRequest(nyIverksett)
-        tilbakekrevingClient.opprettBehandling(opprettTilbakekrevingRequest)
-        tilstandRepository.oppdaterTilbakekrevingResultat(
-                behandlingId = behandlingId,
-                TilbakekrevingResultat(opprettTilbakekrevingRequest))
-
-        // Burde iverksett oppdateres i DBen, siden tilbakekreving potensielt er endret?
-        // iverksettingRepository.lagreIverksett(behandlingId,nyIverksett)
-        logger.info("Opprettet tilbakekrevingsbehandling for behandling=${behandlingId}")
-    }
 
     private fun loggForskjell(nyIverksett: Iverksett,
                               iverksett: Iverksett,

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/TilbakekrevingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/TilbakekrevingUtil.kt
@@ -19,9 +19,7 @@ fun Iverksett.oppfriskTilbakekreving(beriketSimuleringsresultat: BeriketSimuleri
     val simuleringsoppsummering = beriketSimuleringsresultat.oppsummering
 
     val nyTilbakekreving: Tilbakekrevingsdetaljer? =
-            if (tilbakekreving == null && simuleringsoppsummering.harFeilutbetaling)
-                TILBAKEKREVING_UTEN_VARSEL
-            else if (tilbakekreving != null && !simuleringsoppsummering.harFeilutbetaling)
+            if (tilbakekreving != null  && !simuleringsoppsummering.harFeilutbetaling)
                 null
             else if (harAvvikIVarsel(tilbakekreving, simuleringsoppsummering))
                 tilbakekreving?.oppdaterVarsel(simuleringsoppsummering)

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/OpprettTilbakekrevingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/OpprettTilbakekrevingTaskTest.kt
@@ -55,12 +55,13 @@ internal class OpprettTilbakekrevingTaskTest {
     }
 
     @Test
-    fun `uendret og ingen feilutbetaling`() {
+    fun `uendret og ingen feilutbetaling - ikke opprett tilbakekreving`() {
 
+        val tilbakekreving = null
         val behandlingsId = UUID.randomUUID()
-        val iverksett =
-                opprettIverksettOvergangsstønad(behandlingsId, tilbakekreving = null, forrigeBehandlingId = UUID.randomUUID())
-
+        val iverksett = opprettIverksettOvergangsstønad(behandlingsId,
+                                                        tilbakekreving = tilbakekreving,
+                                                        forrigeBehandlingId = UUID.randomUUID())
         every { iverksettingRepository.hent(behandlingsId) } returns iverksett
 
         doTask(behandlingsId)

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/TilbakekrevingUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/TilbakekrevingUtilTest.kt
@@ -131,17 +131,4 @@ internal class TilbakekrevingUtilTest {
         assertThat(nyTilbakekreving).isNull()
     }
 
-    @Test
-    fun `oppdagelse av feilutbetaling i iverksett skal legge til tilbakekreving uten varsel`() {
-
-        val iverksett = opprettIverksettOvergangsstønad(UUID.randomUUID(), tilbakekreving = null)
-
-        val beriketSimuleringsresultat = beriketSimuleringsresultat(BigDecimal.TEN, fom, tom)
-
-        val nyTilbakekreving = iverksett.oppfriskTilbakekreving(beriketSimuleringsresultat).vedtak.tilbakekreving
-
-        assertThat(nyTilbakekreving).isNotNull
-        assertThat(nyTilbakekreving!!.tilbakekrevingsvalg).isEqualTo(Tilbakekrevingsvalg.OPPRETT_TILBAKEKREVING_UTEN_VARSEL)
-        assertThat(nyTilbakekreving.tilbakekrevingMedVarsel).isNull()
-    }
 }


### PR DESCRIPTION
Vil ikke lage tilbakekreving gitt endringer skjedd i periode mellom saksbehandling og beslutter. Dersom det ikke ble valgt å opprette tilbakekreving under saksbehandling gjør vi det heller ikke automatisk i når vi iverksetter. 

Samme som tidligere PR-draft, her uten refaktorering

Dette er versjon en (funksjonelle endringer) versjon2 = refaktorering av OpprettTilbakekrevingTask->doTask..


https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8288