### PR TITLE
Konsistensavstemming tidspunkt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <prosessering.version>1.20220321101749_55e4576</prosessering.version>
         <changelist>-SNAPSHOT</changelist>
         <start-class>no.nav.familie.ef.iverksett.ApplicationKt</start-class>
-        <familie.kontrakter.version>2.0_20220429151635_4bb9f6d</familie.kontrakter.version>
+        <familie.kontrakter.version>2.0_20220504142624_6842a71</familie.kontrakter.version>
         <familie.eksterne-kontrakter.stonadsstatistikk-ef>2.0_20220502125212_55aff01</familie.eksterne-kontrakter.stonadsstatistikk-ef>
         <familie.eksterne-kontrakter.saksstatistikk-ef>2.0_20220107115927_4388dc5</familie.eksterne-kontrakter.saksstatistikk-ef>
         <token-validation-spring.version>2.0.15</token-validation-spring.version>

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/konsistens/KonsistensavstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/konsistens/KonsistensavstemmingService.kt
@@ -37,7 +37,7 @@ class KonsistensavstemmingService(
             val konsistensavstemmingUtbetalingsoppdrag = KonsistensavstemmingUtbetalingsoppdrag(
                     konsistensavstemmingDto.stønadType.tilKlassifisering(),
                     utbetalingsoppdrag,
-                    LocalDateTime.now()
+                    konsistensavstemmingDto.avstemmingstidspunkt ?: LocalDateTime.now()
             )
             oppdragKlient.konsistensavstemming(konsistensavstemmingUtbetalingsoppdrag,
                                                sendStartmelding,
@@ -50,6 +50,8 @@ class KonsistensavstemmingService(
 
     private fun lagUtbetalingsoppdragForKonsistensavstemming(konsistensavstemmingDto: KonsistensavstemmingDto)
             : List<Utbetalingsoppdrag> {
+        if (konsistensavstemmingDto.tilkjenteYtelser.isEmpty()) return emptyList()
+
         val stønadType = konsistensavstemmingDto.stønadType
         val tilkjentYtelsePerBehandlingId = konsistensavstemmingDto.tilkjenteYtelser.associateBy { it.behandlingId }
         val behandlingIdTilkjentYtelseForUtbetalingMap = tilstandRepository.hentTilkjentYtelse(tilkjentYtelsePerBehandlingId.keys)


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8559

Sender med tidspunkt fra requesten i stedet sånn att alle konsistensavstemminger har samme tidspunkt for konsistensavstemming
Tidligere ble den satt her i iverksatt, då vi kun sendte en melding om det.

Når vi sender start- og sluttmelding så sender vi ikke noen tilkjente ytelser, det feilet ved uthenting fra databasen, så det er også fikset

* https://github.com/navikt/familie-ef-sak/pull/1459