### PR TITLE
Tar i bruk HA-hostname for arena MQ for bedre håndtering av nedetid a…

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -124,7 +124,7 @@ management:
 arena-mq:
   queueManager: MPLS01
   channel: P_FAMILIE_EF_IVERKS
-  hostname: a01apvl247.adeo.no
+  hostname: mpls01.adeo.no
   port: 1414
   queueName: QA.P475.SOB_VEDTAKHENDELSER_ARE
   servicebruker: ${SERVICEBRUKER}


### PR DESCRIPTION
…v mq

Denne ble tidligere rullet tilbake fordi hosten ikke var tilgjengelig fra GCP, men den ska nå være tilgjengelig https://jira.adeo.no/browse/IKT-421945
* https://github.com/navikt/familie-ef-iverksett/pull/432