### PR TITLE
Når utbetalingsperiodene er tomme så iverksetter vi ikke mot oppdrag,…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/IverksettingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/IverksettingService.kt
@@ -101,6 +101,9 @@ class IverksettingService(val taskRepository: TaskRepository,
                 }
             }
             it.tilkjentYtelseForUtbetaling?.let {
+                if (it.utbetalingsoppdrag?.utbetalingsperiode?.isEmpty() == true) {
+                    return IverksettStatus.OK_MOT_OPPDRAG
+                }
                 return IverksettStatus.SENDT_TIL_OPPDRAG
             }
             return IverksettStatus.IKKE_PÅBEGYNT


### PR DESCRIPTION
… og kan returnere OK_MOT_OPPDRAG for å unngå kompleks logikk i VentePåStatusFraIverksett i ef-sak