### PR TITLE
Spring jdbc logger warning pga "mapping" av dobbel behandling_id

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/IverksettingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/IverksettingController.kt
@@ -40,7 +40,7 @@ class IverksettingController(
         val iverksett = iverksettDto.toDomain()
         valider(iverksett)
         validerSkalHaBrev(iverksett)
-        iverksettingService.startIverksetting(iverksett, opprettBrev(iverksettDto, fil))
+        iverksettingService.startIverksetting(iverksett, opprettBrev(fil))
     }
 
     @PostMapping("migrering", "uten-brev")
@@ -63,8 +63,8 @@ class IverksettingController(
         return ResponseEntity.ok().build()
     }
 
-    private fun opprettBrev(iverksettDto: IverksettDto, fil: MultipartFile): Brev {
-        return Brev(iverksettDto.behandling.behandlingId, fil.bytes)
+    private fun opprettBrev(fil: MultipartFile): Brev {
+        return Brev(fil.bytes)
     }
 
     private fun validerUtenBrev(iverksettData: IverksettData) {

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/domene/Brev.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/domene/Brev.kt
@@ -1,8 +1,3 @@
 package no.nav.familie.ef.iverksett.iverksetting.domene
 
-import java.util.UUID
-
-data class Brev(
-    val behandlingId: UUID,
-    val pdf: ByteArray
-)
+data class Brev(val pdf: ByteArray)

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/domene/Brev.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/domene/Brev.kt
@@ -1,3 +1,3 @@
 package no.nav.familie.ef.iverksett.iverksetting.domene
 
-data class Brev(val pdf: ByteArray)
+class Brev(val pdf: ByteArray)

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/domene/Iverksett.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/domene/Iverksett.kt
@@ -2,10 +2,8 @@ package no.nav.familie.ef.iverksett.iverksetting.domene
 
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.MappedCollection
-import org.springframework.data.relational.core.mapping.Table
 import java.util.UUID
 
-@Table("iverksett")
 data class Iverksett(
     @Id
     val behandlingId: UUID,

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brev/JournalførVedtaksbrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brev/JournalførVedtaksbrevTaskTest.kt
@@ -62,7 +62,7 @@ internal class JournalførVedtaksbrevTaskTest {
         iverksettDto.behandling.behandlingId,
         iverksettDto.toDomain(),
         iverksettDto.behandling.eksternId,
-        Brev(behandlingId, ByteArray(256))
+        Brev(ByteArray(256))
     )
 
     @BeforeEach

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/util/IverksettMockUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/util/IverksettMockUtil.kt
@@ -340,7 +340,7 @@ fun startmåned(andeler: List<AndelTilkjentYtelse>) =
     andeler.minOfOrNull { it.periode.fom } ?: error("Trenger å sette startdato hvs det ikke finnes andeler")
 
 fun opprettBrev(): Brev {
-    return Brev(UUID.fromString("234bed7c-b1d3-11eb-8529-0242ac130003"), ByteArray(256))
+    return Brev(ByteArray(256))
 }
 
 fun opprettFrittståendeBrevDto(): FrittståendeBrevDto {


### PR DESCRIPTION
Får å unngå log-warning av `ResultSet contains brev_behandling_id multiple times`, då `behandling_id` finnes i `Brev` og i `Iverksett` med `@MappedCollection(idColumn = "behandling_id")`
https://logs.adeo.no/app/discover#/doc/96e648c0-980a-11e9-830a-e17bbd64b4db/logstash-apps-prod-005289?id=4aKmp4IBJWgcveyvbf98

Endret også Brev til å være `class` i stedet for `data class`, då `data class` likevel må overridea hashcode og equals når man har en array. Vet ikke om vi har noe behov for å sjekke at inneholdet er lik i et brev? Eller burde vi det? 

