### PR TITLE
Tea-9958_fjern_ba_mottak

### DIFF
--- a/kafka-aiven/overgangsstønad-infotrygd-vedtak/topic-infotrygd-dev.yaml
+++ b/kafka-aiven/overgangsstønad-infotrygd-vedtak/topic-infotrygd-dev.yaml
@@ -19,9 +19,6 @@ spec:
       application: familie-ef-iverksett
       access: read
     - team: teamfamilie
-      application: familie-ba-mottak
-      access: read
-    - team: teamfamilie
       application: familie-baks-mottak
       access: read
     - team: teamfamilie

--- a/kafka-aiven/overgangsstønad-infotrygd-vedtak/topic-infotrygd-prod.yaml
+++ b/kafka-aiven/overgangsstønad-infotrygd-vedtak/topic-infotrygd-prod.yaml
@@ -19,9 +19,6 @@ spec:
       application: familie-ef-iverksett
       access: read
     - team: teamfamilie
-      application: familie-ba-mottak
-      access: read
-    - team: teamfamilie
       application: familie-baks-mottak
       access: read
     - team: teamfamilie

--- a/kafka-aiven/vedtak/topic-vedtak-dev.yaml
+++ b/kafka-aiven/vedtak/topic-vedtak-dev.yaml
@@ -19,9 +19,6 @@ spec:
       application: familie-ef-iverksett
       access: readwrite
     - team: teamfamilie
-      application: familie-ba-mottak
-      access: read
-    - team: teamfamilie
       application: familie-baks-mottak
       access: read
     - team: teamfamilie

--- a/kafka-aiven/vedtak/topic-vedtak-prod.yaml
+++ b/kafka-aiven/vedtak/topic-vedtak-prod.yaml
@@ -19,9 +19,6 @@ spec:
       application: familie-ef-iverksett
       access: readwrite
     - team: teamfamilie
-      application: familie-ba-mottak
-      access: read
-    - team: teamfamilie
       application: familie-baks-mottak
       access: read
     - team: teamfamilie


### PR DESCRIPTION
Vi fjerner familie-ba-mottak(fss) da familie-baks-mottak(gcp) har tatt over.