### PR TITLE
Definerer eksplisitt dei query-params som faktisk blir sendt inn for finnMappeRequest

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveClient.kt
@@ -60,7 +60,8 @@ class OppgaveClient(
     fun finnMapper(finnMappeRequest: FinnMappeRequest): FinnMappeResponseDto {
         val response = getForEntity<Ressurs<FinnMappeResponseDto>>(
             UriComponentsBuilder.fromUri(URI.create("$oppgaveUrl/mappe/sok"))
-                .queryParams(finnMappeRequest.toQueryParams())
+                .queryParam("enhetsnr", finnMappeRequest.enhetsnr)
+                .queryParam("limit", finnMappeRequest.limit)
                 .build()
                 .toUri()
         )

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveClient.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ef.iverksett.util.medContentTypeJsonUTF8
 import no.nav.familie.http.client.AbstractRestClient
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.getDataOrThrow
-import no.nav.familie.kontrakter.felles.oppgave.FinnMappeRequest
 import no.nav.familie.kontrakter.felles.oppgave.FinnMappeResponseDto
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveResponseDto
@@ -57,11 +56,11 @@ class OppgaveClient(
         return response.getDataOrThrow()
     }
 
-    fun finnMapper(finnMappeRequest: FinnMappeRequest): FinnMappeResponseDto {
+    fun finnMapper(enhetsnummer: String, limit: Long): FinnMappeResponseDto {
         val response = getForEntity<Ressurs<FinnMappeResponseDto>>(
             UriComponentsBuilder.fromUri(URI.create("$oppgaveUrl/mappe/sok"))
-                .queryParam("enhetsnr", finnMappeRequest.enhetsnr)
-                .queryParam("limit", finnMappeRequest.limit)
+                .queryParam("enhetsnr", enhetsnummer)
+                .queryParam("limit", limit)
                 .build()
                 .toUri()
         )

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/barnsalder/OpprettOppgaverForBarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/barnsalder/OpprettOppgaverForBarnService.kt
@@ -7,7 +7,6 @@ import no.nav.familie.ef.iverksett.util.ObjectMapperProvider.objectMapper
 import no.nav.familie.kontrakter.ef.iverksett.OppgaveForBarn
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
-import no.nav.familie.kontrakter.felles.oppgave.FinnMappeRequest
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.domene.Task
@@ -97,13 +96,10 @@ class OpprettOppgaverForBarnService(
     fun leggOppgaveIMappe(oppgaveId: Long) {
         val oppgave = oppgaveClient.finnOppgaveMedId(oppgaveId)
         if (oppgave.tildeltEnhetsnr == EF_ENHETNUMMER) { // Skjermede personer skal ikke puttes i mappe
-            val finnMappeRequest = FinnMappeRequest(
-                listOf(),
-                oppgave.tildeltEnhetsnr ?: error("Fikk ikke tildelt enhetsnummer for oppgave med id: $oppgaveId"),
-                null,
-                1000
+            val mapperResponse = oppgaveClient.finnMapper(
+                enhetsnummer = oppgave.tildeltEnhetsnr ?: error("Fikk ikke tildelt enhetsnummer for oppgave med id: $oppgaveId"),
+                limit = 1000
             )
-            val mapperResponse = oppgaveClient.finnMapper(finnMappeRequest)
             val mappe = mapperResponse.mapper.find {
                 it.navn.contains("62 Hendelser") && !it.navn.contains("EF Sak")
             }


### PR DESCRIPTION
Tilretteleggjing for å fjerne toQueryParams-metoden, som fører med seg mykje unødig kompleksitet

Legg til rette for https://github.com/navikt/familie-kontrakter/pull/684