### PR TITLE
Arbeidsoppfølging skal motta vedtaksdata fra ef for å kunne bruke det…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <familie.kontrakter.version>2.0_20221213103954_b3f2d13</familie.kontrakter.version>
         <familie.eksterne-kontrakter.stonadsstatistikk-ef>2.0_20221122145156_a922c71</familie.eksterne-kontrakter.stonadsstatistikk-ef>
         <familie.eksterne-kontrakter.saksstatistikk-ef>2.0_20221122130110_53c42d4</familie.eksterne-kontrakter.saksstatistikk-ef>
+        <familie.eksterne-kontrakter.arbeidsoppfolging>2.0_20230203094245_a4a6d4d</familie.eksterne-kontrakter.arbeidsoppfolging>
         <prosessering.version>1.20221110194901_e9e0d90</prosessering.version>
         <maven-surefire-plugin.version>3.0.0-M8</maven-surefire-plugin.version>
         <mockk.version>1.13.4</mockk.version>
@@ -162,6 +163,11 @@
             <groupId>no.nav.familie.eksterne.kontrakter</groupId>
             <artifactId>saksstatistikk-ef</artifactId>
             <version>${familie.eksterne-kontrakter.saksstatistikk-ef}</version>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.familie.eksterne.kontrakter</groupId>
+            <artifactId>arbeidsoppfolging</artifactId>
+            <version>${familie.eksterne-kontrakter.arbeidsoppfolging}</version>
         </dependency>
         <dependency>
             <groupId>no.nav.security</groupId>

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/ArbeidsoppfølgingKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/ArbeidsoppfølgingKafkaProducer.kt
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component
 @Component
 class ArbeidsoppfølgingKafkaProducer(private val kafkaProducerService: KafkaProducerService) {
 
-    @Value("\${ENSLIG_FORSORGER_VEDTAK_TOPIC}")
+    @Value("\${ARBEIDSOPPFOLGING_VEDTAK_TOPIC}")
     lateinit var topic: String
 
     private val logger = LoggerFactory.getLogger(javaClass)

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/ArbeidsoppfølgingKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/ArbeidsoppfølgingKafkaProducer.kt
@@ -22,12 +22,12 @@ class ArbeidsoppfølgingKafkaProducer(private val kafkaProducerService: KafkaPro
         sendVedtak(vedtakOvergangsstønadArbeidsoppfølging.vedtakId, vedtakOvergangsstønadArbeidsoppfølging.stønadstype, vedtakOvergangsstønadArbeidsoppfølging.toJson())
     }
 
-    fun sendVedtak(behandlingId: Long, stønadstype: Stønadstype, vedtakStatistikk: String) {
+    fun sendVedtak(behandlingId: Long, stønadstype: Stønadstype, vedtakArbeidsoppfølging: String) {
         logger.info("Sending to Kafka topic: {}", topic)
-        secureLogger.debug("Sending to Kafka topic: {}\nArbeidsoppfølging: {}", topic, vedtakStatistikk)
+        secureLogger.debug("Sending to Kafka topic: {}\nArbeidsoppfølging: {}", topic, vedtakArbeidsoppfølging)
 
         runCatching {
-            kafkaProducerService.sendMedStønadstypeIHeader(topic, StønadType.valueOf(stønadstype.name), behandlingId.toString(), vedtakStatistikk)
+            kafkaProducerService.sendMedStønadstypeIHeader(topic, StønadType.valueOf(stønadstype.name), behandlingId.toString(), vedtakArbeidsoppfølging)
             logger.info("Arbeidsoppfølging for behandling=$behandlingId sent til Kafka")
         }.onFailure {
             val errorMessage = "Kunne ikke sende vedtak til arbeidsoppfølging topic. Se securelogs for mer informasjon."

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/ArbeidsoppfølgingKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/ArbeidsoppfølgingKafkaProducer.kt
@@ -1,0 +1,37 @@
+package no.nav.familie.ef.iverksett.arbeidsoppfolging
+
+import no.nav.familie.ef.iverksett.infrastruktur.service.KafkaProducerService
+import no.nav.familie.ef.iverksett.vedtakstatistikk.toJson
+import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Stønadstype
+import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.VedtakOvergangsstønadArbeidsoppfølging
+import no.nav.familie.eksterne.kontrakter.ef.StønadType
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class ArbeidsoppfølgingKafkaProducer(private val kafkaProducerService: KafkaProducerService) {
+
+    @Value("\${ENSLIG_FORSORGER_VEDTAK_TOPIC}")
+    lateinit var topic: String
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    fun sendVedtak(vedtakOvergangsstønadArbeidsoppfølging: VedtakOvergangsstønadArbeidsoppfølging) {
+        sendVedtak(vedtakOvergangsstønadArbeidsoppfølging.vedtakId, vedtakOvergangsstønadArbeidsoppfølging.stønadstype, vedtakOvergangsstønadArbeidsoppfølging.toJson())
+    }
+    fun sendVedtak(behandlingId: Long, stønadstype: Stønadstype, vedtakStatistikk: String) {
+        logger.info("Sending to Kafka topic: {}", topic)
+        secureLogger.debug("Sending to Kafka topic: {}\nArbeidsoppfølging: {}", topic, vedtakStatistikk)
+
+        runCatching {
+            kafkaProducerService.sendMedStønadstypeIHeader(topic, StønadType.valueOf(stønadstype.name), behandlingId.toString(), vedtakStatistikk)
+            logger.info("Arbeidsoppfølging for behandling=$behandlingId sent til Kafka")
+        }.onFailure {
+            val errorMessage = "Kunne ikke sende vedtak til arbeidsoppfølging topic. Se securelogs for mer informasjon."
+            logger.error(errorMessage)
+            secureLogger.error("Kunne ikke sende vedtak til arbeidsoppfølging topic", it)
+            throw RuntimeException(errorMessage)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/ArbeidsoppfølgingKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/ArbeidsoppfølgingKafkaProducer.kt
@@ -17,9 +17,11 @@ class ArbeidsoppfølgingKafkaProducer(private val kafkaProducerService: KafkaPro
 
     private val logger = LoggerFactory.getLogger(javaClass)
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
+
     fun sendVedtak(vedtakOvergangsstønadArbeidsoppfølging: VedtakOvergangsstønadArbeidsoppfølging) {
         sendVedtak(vedtakOvergangsstønadArbeidsoppfølging.vedtakId, vedtakOvergangsstønadArbeidsoppfølging.stønadstype, vedtakOvergangsstønadArbeidsoppfølging.toJson())
     }
+
     fun sendVedtak(behandlingId: Long, stønadstype: Stønadstype, vedtakStatistikk: String) {
         logger.info("Sending to Kafka topic: {}", topic)
         secureLogger.debug("Sending to Kafka topic: {}\nArbeidsoppfølging: {}", topic, vedtakStatistikk)

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/ArbeidsoppfølgingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/ArbeidsoppfølgingMapper.kt
@@ -1,0 +1,38 @@
+package no.nav.familie.ef.iverksett.arbeidsoppfolging
+
+import no.nav.familie.ef.iverksett.iverksetting.domene.IverksettOvergangsstønad
+import no.nav.familie.ef.iverksett.iverksetting.domene.VedtaksdetaljerOvergangsstønad
+import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Aktivitetstype
+import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Barn
+import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Periode
+import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Periodetype
+import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Stønadstype
+import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.VedtakOvergangsstønadArbeidsoppfølging
+import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Vedtaksresultat
+
+object ArbeidsoppfølgingMapper {
+
+    fun mapTilVedtakOvergangsstønadTilArbeidsoppfølging(
+        iverksett: IverksettOvergangsstønad,
+    ): VedtakOvergangsstønadArbeidsoppfølging {
+        return VedtakOvergangsstønadArbeidsoppfølging(
+            vedtakId = iverksett.behandling.eksternId,
+            personIdent = iverksett.søker.personIdent,
+            barn = iverksett.søker.barn.map { Barn(it.personIdent, it.termindato) },
+            stønadstype = Stønadstype.valueOf(iverksett.fagsak.stønadstype.name),
+            vedtaksresultat = Vedtaksresultat.valueOf(iverksett.vedtak.vedtaksresultat.name),
+            periode = mapToVedtaksperioder(iverksett.vedtak),
+        )
+    }
+
+    fun mapToVedtaksperioder(vedtaksdetaljer: VedtaksdetaljerOvergangsstønad): List<Periode> {
+        return vedtaksdetaljer.vedtaksperioder.map {
+            Periode(
+                it.periode.fomDato,
+                it.periode.tomDato,
+                Periodetype.valueOf(it.periodeType.name),
+                Aktivitetstype.valueOf(it.aktivitet.name),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/ArbeidsoppfølgingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/ArbeidsoppfølgingService.kt
@@ -1,0 +1,19 @@
+package no.nav.familie.ef.iverksett.arbeidsoppfolging
+
+import no.nav.familie.ef.iverksett.iverksetting.domene.IverksettData
+import no.nav.familie.ef.iverksett.iverksetting.domene.IverksettOvergangsstønad
+import org.springframework.stereotype.Service
+
+@Service
+class ArbeidsoppfølgingService(
+    private val arbeidsoppfølgingKafkaProducer: ArbeidsoppfølgingKafkaProducer,
+) {
+
+    fun sendTilKafka(iverksettData: IverksettData) {
+        if (iverksettData is IverksettOvergangsstønad) {
+            arbeidsoppfølgingKafkaProducer.sendVedtak(
+                ArbeidsoppfølgingMapper.mapTilVedtakOvergangsstønadTilArbeidsoppfølging(iverksettData),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/SendVedtakTilArbeidsoppfølgingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/SendVedtakTilArbeidsoppfølgingTask.kt
@@ -1,0 +1,38 @@
+package no.nav.familie.ef.iverksett.arbeidsoppfolging
+
+import no.nav.familie.ef.iverksett.infrastruktur.task.opprettNestePubliseringTask
+import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
+import no.nav.familie.ef.iverksett.repository.findByIdOrThrow
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.internal.TaskService
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = SendVedtakTilArbeidsoppfølgingTask.TYPE,
+    beskrivelse = "Sender vedtaksperioder til arbeidsoppfølging.",
+    settTilManuellOppfølgning = true,
+)
+class SendVedtakTilArbeidsoppfølgingTask(
+    private val taskService: TaskService,
+    private val iverksettingRepository: IverksettingRepository,
+    private val arbeidsoppfølgingService: ArbeidsoppfølgingService,
+) : AsyncTaskStep {
+
+    override fun doTask(task: Task) {
+        val behandlingId = UUID.fromString(task.payload)
+        val iverksett = iverksettingRepository.findByIdOrThrow(behandlingId).data
+        arbeidsoppfølgingService.sendTilKafka(iverksett)
+    }
+
+    override fun onCompletion(task: Task) {
+        taskService.save(task.opprettNestePubliseringTask())
+    }
+
+    companion object {
+        const val TYPE = "sendVedtakTilArbeidsoppfølging"
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskFlyt.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskFlyt.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.iverksett.infrastruktur.task
 
+import no.nav.familie.ef.iverksett.arbeidsoppfolging.SendVedtakTilArbeidsoppfølgingTask
 import no.nav.familie.ef.iverksett.arena.SendFattetVedtakTilArenaTask
 import no.nav.familie.ef.iverksett.brev.DistribuerVedtaksbrevTask
 import no.nav.familie.ef.iverksett.brev.JournalførVedtaksbrevTask
@@ -32,6 +33,7 @@ fun publiseringsflyt() = listOf(
     TaskType(SendPerioderTilInfotrygdTask.TYPE), // Hopper til vedtakstatistikk ved migrering
     TaskType(SendFattetVedtakTilArenaTask.TYPE),
     TaskType(PubliserVedtakTilKafkaTask.TYPE),
+    TaskType(SendVedtakTilArbeidsoppfølgingTask.TYPE),
     TaskType(OpprettOppfølgingsOppgaveForOvergangsstønadTask.TYPE),
     TaskType(VedtakstatistikkTask.TYPE),
 )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -149,6 +149,7 @@ FAMILIE_TILBAKE_SCOPE: api://${DEPLOY_ENV}-gcp.teamfamilie.familie-tilbake/.defa
 
 ENSLIG_FORSORGER_VEDTAK_TOPIC: teamfamilie.aapen-ensligforsorger-vedtak-v1
 ENSLIG_FORSORGER_BEHANDLING_TOPIC: teamfamilie.aapen-ensligforsorger-behandling-v1
+ARBEIDSOPPFOLGING_VEDTAK_TOPIC: teamfamilie.aapen-ensligforsorger-vedtak-arbeidsoppfolging
 VEDTAK_TOPIC: teamfamilie.aapen-ensligforsorger-iverksatt-vedtak
 FAGSYSTEMBEHANDLING_RESPONS_TOPIC: teamfamilie.privat-tbk-hentfagsystemsbehandling-respons-topic
 

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/ArbeidsoppfølgingMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/ArbeidsoppfølgingMapperTest.kt
@@ -1,0 +1,43 @@
+package no.nav.familie.ef.iverksett.arbeidsoppfolging
+
+import no.nav.familie.ef.iverksett.util.lagMånedsperiode
+import no.nav.familie.ef.iverksett.util.opprettIverksettOvergangsstønad
+import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Aktivitetstype
+import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Barn
+import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Periode
+import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Periodetype
+import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Stønadstype
+import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Vedtaksresultat
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import java.time.LocalDate
+import java.time.YearMonth
+import java.util.*
+
+class ArbeidsoppfølgingMapperTest {
+
+    @Test
+    fun mapTilVedtakOvergangsstønadTilArbeidsoppfølging() {
+        val iverksett = opprettIverksettOvergangsstønad(UUID.randomUUID())
+
+        val vedtakTilArbeidsoppfølging = ArbeidsoppfølgingMapper.mapTilVedtakOvergangsstønadTilArbeidsoppfølging(iverksett)
+
+        Assertions.assertThat(vedtakTilArbeidsoppfølging.vedtakId).isEqualTo(iverksett.behandling.eksternId)
+        Assertions.assertThat(vedtakTilArbeidsoppfølging.stønadstype).isEqualTo(Stønadstype.OVERGANGSSTØNAD)
+        Assertions.assertThat(vedtakTilArbeidsoppfølging.personIdent).isEqualTo(iverksett.søker.personIdent)
+        Assertions.assertThat(vedtakTilArbeidsoppfølging.vedtaksresultat).isEqualTo(Vedtaksresultat.INNVILGET)
+        Assertions.assertThat(vedtakTilArbeidsoppfølging.personIdent).isEqualTo(iverksett.søker.personIdent)
+
+        val forventetPeriode = Periode(
+            lagMånedsperiode(YearMonth.now()).fomDato,
+            lagMånedsperiode(YearMonth.now()).tomDato,
+            Periodetype.HOVEDPERIODE,
+            Aktivitetstype.BARNET_ER_SYKT,
+        )
+
+        Assertions.assertThat(vedtakTilArbeidsoppfølging.periode).isEqualTo(listOf(forventetPeriode))
+
+        val forventetBarnList = listOf(Barn("01010199999"), Barn(null, LocalDate.of(2023, 1, 1)))
+        Assertions.assertThat(vedtakTilArbeidsoppfølging.barn).isEqualTo(listOf(forventetBarnList))
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/ArbeidsoppfølgingMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/ArbeidsoppfølgingMapperTest.kt
@@ -9,6 +9,7 @@ import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Periodetype
 import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Stønadstype
 import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Vedtaksresultat
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import java.time.LocalDate
 import java.time.YearMonth
@@ -22,11 +23,11 @@ class ArbeidsoppfølgingMapperTest {
 
         val vedtakTilArbeidsoppfølging = ArbeidsoppfølgingMapper.mapTilVedtakOvergangsstønadTilArbeidsoppfølging(iverksett)
 
-        Assertions.assertThat(vedtakTilArbeidsoppfølging.vedtakId).isEqualTo(iverksett.behandling.eksternId)
-        Assertions.assertThat(vedtakTilArbeidsoppfølging.stønadstype).isEqualTo(Stønadstype.OVERGANGSSTØNAD)
-        Assertions.assertThat(vedtakTilArbeidsoppfølging.personIdent).isEqualTo(iverksett.søker.personIdent)
-        Assertions.assertThat(vedtakTilArbeidsoppfølging.vedtaksresultat).isEqualTo(Vedtaksresultat.INNVILGET)
-        Assertions.assertThat(vedtakTilArbeidsoppfølging.personIdent).isEqualTo(iverksett.søker.personIdent)
+        assertThat(vedtakTilArbeidsoppfølging.vedtakId).isEqualTo(iverksett.behandling.eksternId)
+        assertThat(vedtakTilArbeidsoppfølging.stønadstype).isEqualTo(Stønadstype.OVERGANGSSTØNAD)
+        assertThat(vedtakTilArbeidsoppfølging.personIdent).isEqualTo(iverksett.søker.personIdent)
+        assertThat(vedtakTilArbeidsoppfølging.vedtaksresultat).isEqualTo(Vedtaksresultat.INNVILGET)
+        assertThat(vedtakTilArbeidsoppfølging.personIdent).isEqualTo(iverksett.søker.personIdent)
 
         val forventetPeriode = Periode(
             lagMånedsperiode(YearMonth.now()).fomDato,
@@ -35,9 +36,9 @@ class ArbeidsoppfølgingMapperTest {
             Aktivitetstype.BARNET_ER_SYKT,
         )
 
-        Assertions.assertThat(vedtakTilArbeidsoppfølging.periode).isEqualTo(listOf(forventetPeriode))
+        assertThat(vedtakTilArbeidsoppfølging.periode).isEqualTo(listOf(forventetPeriode))
 
         val forventetBarnList = listOf(Barn("01010199999"), Barn(null, LocalDate.of(2023, 1, 1)))
-        Assertions.assertThat(vedtakTilArbeidsoppfølging.barn).isEqualTo(listOf(forventetBarnList))
+        assertThat(vedtakTilArbeidsoppfølging.barn).isEqualTo(listOf(forventetBarnList))
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/ArbeidsoppfølgingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/ArbeidsoppfølgingServiceTest.kt
@@ -1,0 +1,37 @@
+package no.nav.familie.ef.iverksett.arbeidsoppfolging
+
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.ef.iverksett.iverksetting.domene.IverksettSkolepenger
+import no.nav.familie.ef.iverksett.util.opprettIverksettBarnetilsyn
+import no.nav.familie.ef.iverksett.util.opprettIverksettOvergangsstønad
+import org.junit.Test
+
+class ArbeidsoppfølgingServiceTest {
+
+    private val arbeidsoppfølgingKafkaProducer = mockk<ArbeidsoppfølgingKafkaProducer>()
+
+    val arbeidsoppfølgingService = ArbeidsoppfølgingService(arbeidsoppfølgingKafkaProducer)
+
+    @Test
+    fun `sendTilKafka hvis overgangsstønad`() {
+        justRun { arbeidsoppfølgingKafkaProducer.sendVedtak(any()) }
+        val iverksett = opprettIverksettOvergangsstønad()
+        arbeidsoppfølgingService.sendTilKafka(iverksett)
+
+        verify(exactly = 1) { arbeidsoppfølgingKafkaProducer.sendVedtak(any()) }
+    }
+
+    @Test
+    fun `ikke sendTilKafka hvis barnetilsyn eller skolepenger`() {
+        justRun { arbeidsoppfølgingKafkaProducer.sendVedtak(any()) }
+        val iverksettBarnetilsyn = opprettIverksettBarnetilsyn()
+        arbeidsoppfølgingService.sendTilKafka(iverksettBarnetilsyn)
+
+        verify(exactly = 0) { arbeidsoppfølgingKafkaProducer.sendVedtak(any()) }
+
+        arbeidsoppfølgingService.sendTilKafka(IverksettSkolepenger(mockk(), mockk(), mockk(), mockk()))
+        verify(exactly = 0) { arbeidsoppfølgingKafkaProducer.sendVedtak(any()) }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskTypeTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskTypeTest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.iverksett.infrastruktur.task
 
+import no.nav.familie.ef.iverksett.arbeidsoppfolging.SendVedtakTilArbeidsoppfølgingTask
 import no.nav.familie.ef.iverksett.arena.SendFattetVedtakTilArenaTask
 import no.nav.familie.ef.iverksett.brev.DistribuerVedtaksbrevTask
 import no.nav.familie.ef.iverksett.brev.JournalførVedtaksbrevTask
@@ -59,7 +60,11 @@ class TaskTypeTest {
         assertThat(publiserVedtakTilKafkaTask.type).isEqualTo(PubliserVedtakTilKafkaTask.TYPE)
         assertThat(publiserVedtakTilKafkaTask.triggerTid).isBefore(LocalDateTime.now().plusMinutes(1))
 
-        val opprettOppgaveTask = publiserVedtakTilKafkaTask.opprettNestePubliseringTask()
+        val sendVedtakTilArbeidsoppfølgingTask = publiserVedtakTilKafkaTask.opprettNestePubliseringTask()
+        assertThat(sendVedtakTilArbeidsoppfølgingTask.type).isEqualTo(SendVedtakTilArbeidsoppfølgingTask.TYPE)
+        assertThat(sendVedtakTilArbeidsoppfølgingTask.triggerTid).isBefore(LocalDateTime.now().plusMinutes(1))
+
+        val opprettOppgaveTask = sendVedtakTilArbeidsoppfølgingTask.opprettNestePubliseringTask()
         assertThat(opprettOppgaveTask.type).isEqualTo(OpprettOppfølgingsOppgaveForOvergangsstønadTask.TYPE)
         assertThat(opprettOppgaveTask.triggerTid).isBefore(LocalDateTime.now().plusMinutes(1))
 

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/util/IverksettMockUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/util/IverksettMockUtil.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.iverksett.brev.domain.DistribuerBrevResultatMap
 import no.nav.familie.ef.iverksett.brev.domain.JournalpostResultat
 import no.nav.familie.ef.iverksett.brev.domain.JournalpostResultatMap
 import no.nav.familie.ef.iverksett.iverksetting.domene.AndelTilkjentYtelse
+import no.nav.familie.ef.iverksett.iverksetting.domene.Barn
 import no.nav.familie.ef.iverksett.iverksetting.domene.Behandlingsdetaljer
 import no.nav.familie.ef.iverksett.iverksetting.domene.Brev
 import no.nav.familie.ef.iverksett.iverksetting.domene.Delvilkårsvurdering
@@ -335,7 +336,7 @@ fun opprettIverksettOvergangsstønad(
         behandling = behandlingsdetaljer(behandlingId, forrigeBehandlingId, behandlingType),
         søker = Søker(
             personIdent = "12345678910",
-            barn = emptyList(),
+            barn = listOf(Barn("01010199999"), Barn(null, LocalDate.of(2023, 1, 1))),
             tilhørendeEnhet = "4489",
             adressebeskyttelse = AdressebeskyttelseGradering.UGRADERT,
         ),

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/FellesTilEksterneKontrakterEnumTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/FellesTilEksterneKontrakterEnumTest.kt
@@ -19,6 +19,10 @@ import no.nav.familie.eksterne.kontrakter.ef.BehandlingÅrsak as BehandlingÅrsa
 import no.nav.familie.eksterne.kontrakter.ef.StønadType as StønadTypeEkstern
 import no.nav.familie.eksterne.kontrakter.ef.VedtaksperiodeType as VedtakPeriodeTypeEkstern
 import no.nav.familie.eksterne.kontrakter.ef.Vilkårsresultat as VilkårsresultatEkstern
+import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Vedtaksresultat as VedtaksresultatEkstern
+import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Periodetype as PeriodetypeEkstern
+import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Aktivitetstype as AktivitetstypeEkstern
+import no.nav.familie.eksterne.kontrakter.arbeidsoppfolging.Stønadstype as StønadstypeEkstern
 
 class FellesTilEksterneKontrakterEnumTest {
 
@@ -33,5 +37,13 @@ class FellesTilEksterneKontrakterEnumTest {
         AktivitetType.values().forEach { AktivitetTypeEkstern.valueOf(it.name) }
         AdressebeskyttelseGradering.values().forEach { AdresseBeskyttelseEkstern.valueOf(it.name) }
         StønadType.values().forEach { StønadTypeEkstern.valueOf(it.name) }
+    }
+
+    @Test
+    fun `for alle arbeidsoppfølging enums i eksterne kontrakter, forvent mapping fra domene`() {
+        Vedtaksresultat.values().forEach { VedtaksresultatEkstern.valueOf(it.name) }
+        VedtaksperiodeType.values().forEach { PeriodetypeEkstern.valueOf(it.name) }
+        AktivitetType.values().forEach { AktivitetstypeEkstern.valueOf(it.name) }
+        StønadType.values().forEach { StønadstypeEkstern.valueOf(it.name) }
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkServiceTest.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ef.iverksett.util.opprettIverksettOvergangsstønad
 import no.nav.familie.eksterne.kontrakter.ef.Adressebeskyttelse
 import no.nav.familie.eksterne.kontrakter.ef.AktivitetType
 import no.nav.familie.eksterne.kontrakter.ef.Aktivitetskrav
+import no.nav.familie.eksterne.kontrakter.ef.Barn
 import no.nav.familie.eksterne.kontrakter.ef.BehandlingType
 import no.nav.familie.eksterne.kontrakter.ef.BehandlingÅrsak
 import no.nav.familie.eksterne.kontrakter.ef.Person
@@ -57,6 +58,7 @@ class VedtakstatistikkServiceTest {
             behandlingId = iverksettOvergangsstønad.behandling.eksternId,
             fagsakId = iverksettOvergangsstønad.fagsak.eksternId,
             tidspunktVedtak = iverksettOvergangsstønad.vedtak.vedtakstidspunkt.toLocalDate(),
+            barn = iverksettOvergangsstønad.søker.barn.map { Barn(it.personIdent, it.termindato) },
         )
         assertThat(vedtakOvergangsstønad).isEqualTo(vedtakstatistikkJsonSlot.captured)
     }
@@ -84,6 +86,7 @@ class VedtakstatistikkServiceTest {
         behandlingId: Long,
         fagsakId: Long,
         tidspunktVedtak: LocalDate,
+        barn: List<Barn> = emptyList(),
     ): VedtakOvergangsstønadDVH {
         return VedtakOvergangsstønadDVH(
             fagsakId = fagsakId,
@@ -98,7 +101,7 @@ class VedtakstatistikkServiceTest {
                 ),
             ),
             person = Person(personIdent = "12345678910"),
-            barn = emptyList(),
+            barn = barn,
             behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
             behandlingÅrsak = BehandlingÅrsak.SØKNAD,
             vedtak = Vedtak.INNVILGET,


### PR DESCRIPTION
… i nytt saksbehandlingsystem for saksbehandlere i lokalkontor. I første omgang ville de håndtere overgangsstønad, men barnetilsyn vil være aktuelt etterhvert. Det skal hovedsaklig brukes til å følge opp aktivitetsplikten. Det er også oppfølging av brukere med barn som fyller halvt år og ett år. Etterhvert som dette blir implementert kan vi oppretting av oppfølgingsoppgaver i oppgaveregisteret fjernes fra vår side. Nøyaktig hva som vil bli erstattet med nytt system vil bli avklart underveis.

[Tea-10630](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10630)