### PR TITLE
Mq outbound policy

### DIFF
--- a/.deploy/nais-preprod.yaml
+++ b/.deploy/nais-preprod.yaml
@@ -54,6 +54,11 @@ spec:
       rules:
         - application: familie-tilbake
       external:
+        - host: b27apvl219.preprod.local
+          ports:
+            - name: mq
+              port: 1413
+              protocol: TCP
         - host: familie-oppdrag.dev-fss-pub.nais.io
         - host: familie-ef-infotrygd-feed.dev-fss-pub.nais.io
   gcp:

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -55,6 +55,11 @@ spec:
       rules:
         - application: familie-tilbake
       external:
+        - host: mpls01.adeo.no
+          ports:
+            - name: mq
+              port: 1414
+              protocol: TCP
         - host: familie-oppdrag.prod-fss-pub.nais.io
         - host: familie-ef-infotrygd-feed.prod-fss-pub.nais.io
   gcp:


### PR DESCRIPTION
Ny network policy har blitt tatt i bruk: https://nav-it.slack.com/archives/C5KUST8N6/p1680085706741319
Må derfor åpne opp for å koble til mq server fra gcp