### PR TITLE
Sender brukernotifikasjon ved G-omregning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <familie.eksterne-kontrakter.saksstatistikk-ef>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.saksstatistikk-ef>
         <familie.eksterne-kontrakter.arbeidsoppfolging>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.arbeidsoppfolging>
         <prosessering.version>2.20230322091650_fb0187e-SPRING_BOOT_3</prosessering.version>
+        <brukernotifikasjon-schemas.version>2.5.1</brukernotifikasjon-schemas.version>
         <maven-surefire-plugin.version>3.0.0-M9</maven-surefire-plugin.version>
         <mockk-jvm.version>1.13.5</mockk-jvm.version>
         <cucumber.version>7.12.0</cucumber.version>
@@ -40,6 +41,10 @@
         <repository>
             <id>confluent</id>
             <url>https://packages.confluent.io/maven/</url>
+        </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
         <repository>
             <id>github</id>
@@ -181,6 +186,11 @@
             <groupId>no.nav.familie.felles</groupId>
             <artifactId>http-client</artifactId>
             <version>${felles.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.navikt</groupId>
+            <artifactId>brukernotifikasjon-schemas</artifactId>
+            <version>${brukernotifikasjon-schemas.version}</version>
         </dependency>
 
         <!-- Database -->

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <familie.eksterne-kontrakter.saksstatistikk-ef>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.saksstatistikk-ef>
         <familie.eksterne-kontrakter.arbeidsoppfolging>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.arbeidsoppfolging>
         <prosessering.version>2.20230322091650_fb0187e-SPRING_BOOT_3</prosessering.version>
-        <brukernotifikasjon-schemas.version>2.5.1</brukernotifikasjon-schemas.version>
+        <brukernotifikasjon-schemas.version>2.5.2</brukernotifikasjon-schemas.version>
         <maven-surefire-plugin.version>3.0.0-M9</maven-surefire-plugin.version>
         <mockk-jvm.version>1.13.5</mockk-jvm.version>
         <cucumber.version>7.12.0</cucumber.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <prosessering.version>2.20230322091650_fb0187e-SPRING_BOOT_3</prosessering.version>
         <brukernotifikasjon-schemas.version>2.5.2</brukernotifikasjon-schemas.version>
         <maven-surefire-plugin.version>3.0.0-M9</maven-surefire-plugin.version>
+        <confluent.version>7.3.3</confluent.version>
         <mockk-jvm.version>1.13.5</mockk-jvm.version>
         <cucumber.version>7.12.0</cucumber.version>
         <revision>1.0</revision>
@@ -99,6 +100,13 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-reflect</artifactId>
+        </dependency>
+
+        <!-- Kafka -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-avro-serializer</artifactId>
+            <version>${confluent.version}</version>
         </dependency>
 
         <!-- Swagger -->

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
@@ -48,7 +48,7 @@ class BrukernotifikasjonKafkaProducer(private val kafkaTemplate: KafkaTemplate<N
             .withEventId(behandlingId.toString())
             .build()
 
-    private fun lagBeskjed(): BeskjedInput {
+    fun lagBeskjed(): BeskjedInput {
         val builder = BeskjedInputBuilder()
             .withSikkerhetsnivaa(4)
             .withSynligFremTil(null)

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
@@ -44,7 +44,7 @@ class BrukernotifikasjonKafkaProducer(private val kafkaTemplate: KafkaTemplate<N
             .withAppnavn("familie-ef-iverksett")
             .withNamespace("teamfamilie")
             .withFodselsnummer(fnr)
-            .withGrupperingsId(UUID.randomUUID().toString()) //Setter random UUID uten å lagre fordi feltet skal fjernes
+            .withGrupperingsId(UUID.randomUUID().toString()) // Setter random UUID uten å lagre fordi feltet skal fjernes
             .withEventId(behandlingId.toString())
             .build()
 

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
@@ -1,0 +1,63 @@
+package no.nav.familie.ef.iverksett.brukernotifikasjon
+
+import no.nav.brukernotifikasjon.schemas.builders.BeskjedInputBuilder
+import no.nav.brukernotifikasjon.schemas.builders.NokkelInputBuilder
+import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
+import no.nav.brukernotifikasjon.schemas.input.NokkelInput
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+import java.time.YearMonth
+import java.time.ZoneOffset
+import java.util.UUID
+
+@Service
+class BrukernotifikasjonKafkaProducer(private val kafkaTemplate: KafkaTemplate<NokkelInput, BeskjedInput>) {
+
+    @Value("\${KAFKA_TOPIC_DITTNAV}")
+    private lateinit var topic: String
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+
+    fun sendBeskjedTilBruker(fnr: String, behandlingId: UUID) {
+        val nokkel = lagNøkkel(fnr, behandlingId)
+        val beskjed = lagBeskjed()
+
+        secureLogger.info("Sender til Kafka topic: {}: {}", topic, beskjed)
+        runCatching {
+            val producerRecord = ProducerRecord(topic, nokkel, beskjed)
+            kafkaTemplate.send(producerRecord).get()
+        }.onFailure {
+            val errorMessage = "Kunne ikke sende brukernotifikasjon til topic: $topic. Se secure logs for mer informasjon."
+            logger.error(errorMessage)
+            secureLogger.error("Kunne ikke sende brukernotifikasjon til topic: {}", topic, it)
+            throw RuntimeException(errorMessage)
+        }
+    }
+
+    private fun lagNøkkel(fnr: String, behandlingId: UUID): NokkelInput =
+        NokkelInputBuilder()
+            .withAppnavn("familie-ef-iverksett")
+            .withNamespace("teamfamilie")
+            .withFodselsnummer(fnr)
+            .withEventId(behandlingId.toString())
+            .build()
+
+    private fun lagBeskjed(): BeskjedInput {
+        val builder = BeskjedInputBuilder()
+            .withSikkerhetsnivaa(4)
+            .withSynligFremTil(null)
+            .withTekst(G_OMREGNING_MELDING)
+            .withTidspunkt(LocalDateTime.now(ZoneOffset.UTC))
+
+        return builder.build()
+    }
+}
+
+val G_OMREGNING_MELDING = """
+    Folketrygdens grunnbeløp er økt til <Nytt G-beløp> kroner pr. år fra 1. mai ${YearMonth.now().year}. Ytelsen er derfor omregnet.
+""".trimIndent()

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
@@ -44,6 +44,7 @@ class BrukernotifikasjonKafkaProducer(private val kafkaTemplate: KafkaTemplate<N
             .withAppnavn("familie-ef-iverksett")
             .withNamespace("teamfamilie")
             .withFodselsnummer(fnr)
+            .withGrupperingsId(UUID.randomUUID().toString()) //Setter random UUID uten å lagre fordi feltet skal fjernes
             .withEventId(behandlingId.toString())
             .build()
 

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
@@ -4,6 +4,7 @@ import no.nav.brukernotifikasjon.schemas.builders.BeskjedInputBuilder
 import no.nav.brukernotifikasjon.schemas.builders.NokkelInputBuilder
 import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
 import no.nav.brukernotifikasjon.schemas.input.NokkelInput
+import no.nav.familie.ef.iverksett.iverksetting.domene.IverksettData
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -23,9 +24,9 @@ class BrukernotifikasjonKafkaProducer(private val kafkaTemplate: KafkaTemplate<N
     private val logger = LoggerFactory.getLogger(javaClass)
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
-    fun sendBeskjedTilBruker(fnr: String, behandlingId: UUID) {
-        val nokkel = lagNøkkel(fnr, behandlingId)
-        val beskjed = lagBeskjed()
+    fun sendBeskjedTilBruker(iverksett: IverksettData, behandlingId: UUID) {
+        val nokkel = lagNøkkel(iverksett.søker.personIdent, behandlingId)
+        val beskjed = lagBeskjed(iverksett)
 
         secureLogger.info("Sender til Kafka topic: {}: {}", topic, beskjed)
         runCatching {
@@ -48,17 +49,36 @@ class BrukernotifikasjonKafkaProducer(private val kafkaTemplate: KafkaTemplate<N
             .withEventId(behandlingId.toString())
             .build()
 
-    fun lagBeskjed(): BeskjedInput {
+    fun lagBeskjed(iverksett: IverksettData): BeskjedInput {
         val builder = BeskjedInputBuilder()
             .withSikkerhetsnivaa(4)
             .withSynligFremTil(null)
-            .withTekst(G_OMREGNING_MELDING)
+            .withTekst(genererGOmregningMelding(iverksett))
             .withTidspunkt(LocalDateTime.now(ZoneOffset.UTC))
 
         return builder.build()
     }
 }
 
-val G_OMREGNING_MELDING = """
-    Folketrygdens grunnbeløp er økt til <Nytt G-beløp> kroner pr. år fra 1. mai ${YearMonth.now().year}. Ytelsen er derfor omregnet.
+fun genererGOmregningMelding(iverksett: IverksettData): String {
+    val melding = if (iverksett.vedtak.tilkjentYtelse?.andelerTilkjentYtelse?.any { it.inntekt > 0 } == true) {
+        gOmregningMedArbeidsinntektMelding(
+            iverksett.vedtak.tilkjentYtelse?.andelerTilkjentYtelse?.first { it.periode.inneholder(YearMonth.now()) }?.inntekt
+                ?: iverksett.vedtak.tilkjentYtelse?.andelerTilkjentYtelse?.first { it.inntekt > 0 }?.inntekt ?: throw Exception("Skulle ha funnet inntekt i andel tilkjent ytelse for behandling ${iverksett.behandling.behandlingId}"),
+        )
+    } else {
+        G_OMREGNING_UTEN_ARBEDSINNTEKT_MELDING
+    }
+
+    return melding
+}
+
+fun gOmregningMedArbeidsinntektMelding(inntekt: Int) = """
+    Fra ${nyesteGrunnbeløp.periode.fomDato.norskFormat()} har folketrygdens grunnbeløp økt til ${nyesteGrunnbeløp.grunnbeløp} kroner og din forventede inntekt er oppjustert til $inntekt kroner. Overgangsstønaden din er derfor endret.
+    Du må si ifra til oss hvis inntekten din øker eller reduseres med 10 prosent eller mer.
+    """.trimIndent()
+
+val G_OMREGNING_UTEN_ARBEDSINNTEKT_MELDING = """
+    Fra ${nyesteGrunnbeløp.periode.fomDato.norskFormat()} har folketrygdens grunnbeløp økt til ${nyesteGrunnbeløp.grunnbeløp} og overgangsstønaden din er derfor endret.
+    Du må si ifra til oss hvis månedsinntekten din blir høyere enn $halvG kroner før skatt.
 """.trimIndent()

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
@@ -63,7 +63,8 @@ class BrukernotifikasjonKafkaProducer(private val kafkaTemplate: KafkaTemplate<N
 fun genererGOmregningMelding(iverksett: IverksettData): String {
     val melding = if (iverksett.vedtak.tilkjentYtelse?.andelerTilkjentYtelse?.any { it.inntekt > 0 } == true) {
         gOmregningMedArbeidsinntektMelding(
-            iverksett.vedtak.tilkjentYtelse?.andelerTilkjentYtelse?.first { it.periode.inneholder(YearMonth.now()) }?.inntekt
+            iverksett.vedtak.tilkjentYtelse?.andelerTilkjentYtelse?.first { it.periode.inneholder(YearMonth.now().plusMonths(1)) && it.inntekt > 0 }?.inntekt
+                ?: iverksett.vedtak.tilkjentYtelse?.andelerTilkjentYtelse?.first { it.periode.inneholder(YearMonth.now()) && it.inntekt > 0 }?.inntekt
                 ?: iverksett.vedtak.tilkjentYtelse?.andelerTilkjentYtelse?.first { it.inntekt > 0 }?.inntekt ?: throw Exception("Skulle ha funnet inntekt i andel tilkjent ytelse for behandling ${iverksett.behandling.behandlingId}"),
         )
     } else {

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/Grunnbeløp.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/Grunnbeløp.kt
@@ -10,7 +10,13 @@ import java.time.format.DateTimeFormatter
 val grunnbeløpsperioder: List<Grunnbeløp> =
     listOf(
         Grunnbeløp(
-            periode = Månedsperiode(YearMonth.parse("2022-05"), YearMonth.from(LocalDate.MAX)),
+            periode = Månedsperiode(YearMonth.parse("2023-05"), YearMonth.from(LocalDate.MAX)),
+            grunnbeløp = 118_620.toBigDecimal(),
+            perMnd = 9_885.toBigDecimal(),
+            gjennomsnittPerÅr = 116_239.toBigDecimal(),
+        ),
+        Grunnbeløp(
+            periode = Månedsperiode(YearMonth.parse("2022-05"), YearMonth.parse("2023-04")),
             grunnbeløp = 111_477.toBigDecimal(),
             perMnd = 9_290.toBigDecimal(),
             gjennomsnittPerÅr = 109_784.toBigDecimal(),

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/Grunnbeløp.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/Grunnbeløp.kt
@@ -1,0 +1,35 @@
+package no.nav.familie.ef.iverksett.brukernotifikasjon
+
+import no.nav.familie.kontrakter.felles.Månedsperiode
+import java.math.BigDecimal
+import java.math.MathContext
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
+
+val grunnbeløpsperioder: List<Grunnbeløp> =
+    listOf(
+        Grunnbeløp(
+            periode = Månedsperiode(YearMonth.parse("2022-05"), YearMonth.from(LocalDate.MAX)),
+            grunnbeløp = 111_477.toBigDecimal(),
+            perMnd = 9_290.toBigDecimal(),
+            gjennomsnittPerÅr = 109_784.toBigDecimal(),
+        ),
+        Grunnbeløp(
+            periode = Månedsperiode("2021-05" to "2022-04"),
+            grunnbeløp = 106_399.toBigDecimal(),
+            perMnd = 8_867.toBigDecimal(),
+            gjennomsnittPerÅr = 104_716.toBigDecimal(),
+        ),
+    )
+val nyesteGrunnbeløp = grunnbeløpsperioder.maxBy { it.periode }
+val nyesteGrunnbeløpGyldigFraOgMed = nyesteGrunnbeløp.periode.fom
+val halvG = nyesteGrunnbeløp.grunnbeløp.divide(BigDecimal(2)).divide(BigDecimal(12)).round(MathContext(0))
+data class Grunnbeløp(
+    val periode: Månedsperiode,
+    val grunnbeløp: BigDecimal,
+    val perMnd: BigDecimal,
+    val gjennomsnittPerÅr: BigDecimal? = null,
+)
+
+fun LocalDate.norskFormat() = this.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTask.kt
@@ -1,0 +1,33 @@
+package no.nav.familie.ef.iverksett.brukernotifikasjon
+
+import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
+import no.nav.familie.ef.iverksett.repository.findByIdOrThrow
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = SendBrukernotifikasjonVedGOmregningTask.TYPE,
+    beskrivelse = "Sender melding til bruker via dittnav om at vedtak er G-omregnet",
+    settTilManuellOppfølgning = true,
+)
+class SendBrukernotifikasjonVedGOmregningTask(
+    val brukernotifikasjonKafkaProducer: BrukernotifikasjonKafkaProducer,
+    val iverksettingRepository: IverksettingRepository,
+) : AsyncTaskStep {
+
+    override fun doTask(task: Task) {
+        val behandlingId = UUID.fromString(task.payload)
+        val iverksett = iverksettingRepository.findByIdOrThrow(behandlingId).data
+        if (iverksett.erGOmregning()) { // Dobbeltsjekk: Tasken skal egentlig ikke være lagd hvis det ikke er G-omregning
+            brukernotifikasjonKafkaProducer.sendBeskjedTilBruker(iverksett.søker.personIdent, behandlingId)
+        }
+    }
+
+    companion object {
+        const val TYPE = "sendBrukernotifikasjonVedGOmregningTask"
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTask.kt
@@ -1,11 +1,13 @@
 package no.nav.familie.ef.iverksett.brukernotifikasjon
 
+import no.nav.familie.ef.iverksett.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
 import no.nav.familie.ef.iverksett.repository.findByIdOrThrow
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 import java.util.UUID
 
 @Service
@@ -17,17 +19,26 @@ import java.util.UUID
 class SendBrukernotifikasjonVedGOmregningTask(
     val brukernotifikasjonKafkaProducer: BrukernotifikasjonKafkaProducer,
     val iverksettingRepository: IverksettingRepository,
+    val featureToggleService: FeatureToggleService,
 ) : AsyncTaskStep {
 
     override fun doTask(task: Task) {
         val behandlingId = UUID.fromString(task.payload)
         val iverksett = iverksettingRepository.findByIdOrThrow(behandlingId).data
-        if (iverksett.erGOmregning()) { // Dobbeltsjekk: Tasken skal egentlig ikke være lagd hvis det ikke er G-omregning
-            brukernotifikasjonKafkaProducer.sendBeskjedTilBruker(iverksett, behandlingId)
+        if (iverksett.erGOmregning() && featureToggleService.isEnabled("familie.ef.sak.g-beregning-scheduler")) { // Dobbeltsjekk: Tasken skal egentlig ikke være lagd hvis det ikke er G-omregning
+            if (nyesteGrunnbeløp.periode.fomDato.plusYears(1) > DatoUtil.dagensDato()) {
+                brukernotifikasjonKafkaProducer.sendBeskjedTilBruker(iverksett, behandlingId)
+            } else {
+                throw RuntimeException("Skal ikke sende melding til dittnav dersom grunnbeløpet ikke er oppdatert")
+            }
         }
     }
 
     companion object {
         const val TYPE = "sendBrukernotifikasjonVedGOmregningTask"
     }
+}
+
+object DatoUtil { // For å kunne mocke dato
+    fun dagensDato() = LocalDate.now()
 }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTask.kt
@@ -23,7 +23,7 @@ class SendBrukernotifikasjonVedGOmregningTask(
         val behandlingId = UUID.fromString(task.payload)
         val iverksett = iverksettingRepository.findByIdOrThrow(behandlingId).data
         if (iverksett.erGOmregning()) { // Dobbeltsjekk: Tasken skal egentlig ikke være lagd hvis det ikke er G-omregning
-            brukernotifikasjonKafkaProducer.sendBeskjedTilBruker(iverksett.søker.personIdent, behandlingId)
+            brukernotifikasjonKafkaProducer.sendBeskjedTilBruker(iverksett, behandlingId)
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/configuration/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/configuration/KafkaConfig.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.ef.iverksett.infrastruktur.configuration
 
+import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
+import no.nav.brukernotifikasjon.schemas.input.NokkelInput
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -17,6 +19,17 @@ class KafkaConfig {
         val producerFactory = DefaultKafkaProducerFactory<String, String>(properties.buildProducerProperties())
 
         return KafkaTemplate(producerFactory).apply<KafkaTemplate<String, String>> {
+            setProducerListener(producerListener)
+        }
+    }
+
+    @Bean
+    fun kafkaTemplateBrukerNotifikasjoner(properties: KafkaProperties): KafkaTemplate<NokkelInput, BeskjedInput> {
+        val producerListener = LoggingProducerListener<NokkelInput, BeskjedInput>()
+        producerListener.setIncludeContents(false)
+        val producerFactory = DefaultKafkaProducerFactory<NokkelInput, BeskjedInput>(properties.buildProducerProperties())
+
+        return KafkaTemplate(producerFactory).apply<KafkaTemplate<NokkelInput, BeskjedInput>> {
             setProducerListener(producerListener)
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/configuration/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/configuration/KafkaConfig.kt
@@ -1,10 +1,12 @@
 package no.nav.familie.ef.iverksett.infrastruktur.configuration
 
 import io.confluent.kafka.serializers.KafkaAvroSerializer
+import io.confluent.kafka.serializers.KafkaAvroSerializerConfig
 import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
 import no.nav.brukernotifikasjon.schemas.input.NokkelInput
 import org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG
 import org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -14,6 +16,15 @@ import org.springframework.kafka.support.LoggingProducerListener
 
 @Configuration
 class KafkaConfig {
+
+    @Value("\${KAFKA_SCHEMA_REGISTRY}")
+    lateinit var schemaRegistryUrl: String
+
+    @Value("\${KAFKA_SCHEMA_REGISTRY_USER}")
+    lateinit var schemaRegistryUser: String
+
+    @Value("\${KAFKA_SCHEMA_REGISTRY_PASSWORD}")
+    lateinit var schemaRegistryPassword: String
 
     @Bean
     fun kafkaTemplate(properties: KafkaProperties): KafkaTemplate<String, String> {
@@ -33,6 +44,9 @@ class KafkaConfig {
         val producerFactory = DefaultKafkaProducerFactory<NokkelInput, BeskjedInput>(properties.buildProducerProperties().apply {
             put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer::class.java)
             put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer::class.java)
+            put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl)
+            put(KafkaAvroSerializerConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO")
+            put(KafkaAvroSerializerConfig.USER_INFO_CONFIG, "$schemaRegistryUser:$schemaRegistryPassword",)
         })
 
         return KafkaTemplate(producerFactory).apply<KafkaTemplate<NokkelInput, BeskjedInput>> {

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/configuration/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/configuration/KafkaConfig.kt
@@ -1,7 +1,10 @@
 package no.nav.familie.ef.iverksett.infrastruktur.configuration
 
+import io.confluent.kafka.serializers.KafkaAvroSerializer
 import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
 import no.nav.brukernotifikasjon.schemas.input.NokkelInput
+import org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG
+import org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -27,7 +30,10 @@ class KafkaConfig {
     fun kafkaTemplateBrukerNotifikasjoner(properties: KafkaProperties): KafkaTemplate<NokkelInput, BeskjedInput> {
         val producerListener = LoggingProducerListener<NokkelInput, BeskjedInput>()
         producerListener.setIncludeContents(false)
-        val producerFactory = DefaultKafkaProducerFactory<NokkelInput, BeskjedInput>(properties.buildProducerProperties())
+        val producerFactory = DefaultKafkaProducerFactory<NokkelInput, BeskjedInput>(properties.buildProducerProperties().apply {
+            put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer::class.java)
+            put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer::class.java)
+        })
 
         return KafkaTemplate(producerFactory).apply<KafkaTemplate<NokkelInput, BeskjedInput>> {
             setProducerListener(producerListener)

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/configuration/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/configuration/KafkaConfig.kt
@@ -41,13 +41,15 @@ class KafkaConfig {
     fun kafkaTemplateBrukerNotifikasjoner(properties: KafkaProperties): KafkaTemplate<NokkelInput, BeskjedInput> {
         val producerListener = LoggingProducerListener<NokkelInput, BeskjedInput>()
         producerListener.setIncludeContents(false)
-        val producerFactory = DefaultKafkaProducerFactory<NokkelInput, BeskjedInput>(properties.buildProducerProperties().apply {
-            put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer::class.java)
-            put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer::class.java)
-            put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl)
-            put(KafkaAvroSerializerConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO")
-            put(KafkaAvroSerializerConfig.USER_INFO_CONFIG, "$schemaRegistryUser:$schemaRegistryPassword",)
-        })
+        val producerFactory = DefaultKafkaProducerFactory<NokkelInput, BeskjedInput>(
+            properties.buildProducerProperties().apply {
+                put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer::class.java)
+                put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer::class.java)
+                put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl)
+                put(KafkaAvroSerializerConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO")
+                put(KafkaAvroSerializerConfig.USER_INFO_CONFIG, "$schemaRegistryUser:$schemaRegistryPassword")
+            },
+        )
 
         return KafkaTemplate(producerFactory).apply<KafkaTemplate<NokkelInput, BeskjedInput>> {
             setProducerListener(producerListener)

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskFlyt.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskFlyt.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ef.iverksett.arbeidsoppfolging.SendVedtakTilArbeidsoppføl
 import no.nav.familie.ef.iverksett.arena.SendFattetVedtakTilArenaTask
 import no.nav.familie.ef.iverksett.brev.DistribuerVedtaksbrevTask
 import no.nav.familie.ef.iverksett.brev.JournalførVedtaksbrevTask
+import no.nav.familie.ef.iverksett.brukernotifikasjon.SendBrukernotifikasjonVedGOmregningTask
 import no.nav.familie.ef.iverksett.infotrygd.SendFattetVedtakTilInfotrygdTask
 import no.nav.familie.ef.iverksett.infotrygd.SendPerioderTilInfotrygdTask
 import no.nav.familie.ef.iverksett.oppgave.OpprettOppfølgingsOppgaveForOvergangsstønadTask
@@ -36,6 +37,7 @@ fun publiseringsflyt() = listOf(
     TaskType(SendVedtakTilArbeidsoppfølgingTask.TYPE),
     TaskType(OpprettOppfølgingsOppgaveForOvergangsstønadTask.TYPE),
     TaskType(VedtakstatistikkTask.TYPE),
+    TaskType(SendBrukernotifikasjonVedGOmregningTask.TYPE),
 )
 
 fun TaskType.nesteHovedflytTask() = hovedflyt().zipWithNext().first { this.type == it.first.type }.second

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkTask.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.iverksett.vedtakstatistikk
 
+import no.nav.familie.ef.iverksett.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.iverksett.infrastruktur.task.opprettNestePubliseringTask
 import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
 import no.nav.familie.ef.iverksett.repository.findByIdOrThrow
@@ -20,6 +21,7 @@ class VedtakstatistikkTask(
     private val iverksettingRepository: IverksettingRepository,
     private val vedtakstatistikkService: VedtakstatistikkService,
     private val taskService: TaskService,
+    private val featureToggleService: FeatureToggleService,
 ) : AsyncTaskStep {
 
     override fun doTask(task: Task) {
@@ -32,7 +34,7 @@ class VedtakstatistikkTask(
     override fun onCompletion(task: Task) {
         val behandlingId = UUID.fromString(task.payload)
         val iverksett = iverksettingRepository.findByIdOrThrow(behandlingId).data
-        if (iverksett.erGOmregning()) {
+        if (iverksett.erGOmregning() && featureToggleService.isEnabled("familie.ef.sak.g-beregning-scheduler")) {
             taskService.save(task.opprettNestePubliseringTask())
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -39,7 +39,7 @@ object UtbetalingsoppdragGenerator {
             andelerForrigeTilkjentYtelse,
             andelerNyTilkjentYtelse,
             nyTilkjentYtelse.startmåned,
-            forrigeTilkjentYtelse?.startmåned
+            forrigeTilkjentYtelse?.startmåned,
         )
 
         val andelerTilOpprettelse = andelerTilOpprettelse(andelerNyTilkjentYtelse, beståendeAndeler)
@@ -149,7 +149,7 @@ object UtbetalingsoppdragGenerator {
     private fun sistePeriodeId(tilkjentYtelse: TilkjentYtelse?): PeriodeId? {
         return tilkjentYtelse?.let { ytelse ->
             ytelse.sisteAndelIKjede?.tilPeriodeId()
-            // TODO denne kan fjernes når den er patchet
+                // TODO denne kan fjernes når den er patchet
                 ?: ytelse.andelerTilkjentYtelse.filter { it.periodeId != null }.maxByOrNull { it.periodeId!! }?.tilPeriodeId()
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -152,7 +152,7 @@ ENSLIG_FORSORGER_BEHANDLING_TOPIC: teamfamilie.aapen-ensligforsorger-behandling-
 ARBEIDSOPPFOLGING_VEDTAK_TOPIC: teamfamilie.aapen-ensligforsorger-vedtak-arbeidsoppfolging
 VEDTAK_TOPIC: teamfamilie.aapen-ensligforsorger-iverksatt-vedtak
 FAGSYSTEMBEHANDLING_RESPONS_TOPIC: teamfamilie.privat-tbk-hentfagsystemsbehandling-respons-topic
-
+KAFKA_TOPIC_DITTNAV: min-side.aapen-brukernotifikasjon-beskjed-v1
 prosessering:
   continuousRunning.enabled: true
   fixedDelayString:

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
@@ -187,7 +187,7 @@ fun lagIverksettData(
     årsak: BehandlingÅrsak = BehandlingÅrsak.SØKNAD,
     vedtakstidspunkt: LocalDateTime = LocalDateTime.of(2021, 5, 12, 0, 0),
     andeler: List<AndelTilkjentYtelse> = andelsdatoer.map {
-        lagAndelTilkjentYtelse(beløp = 0, fraOgMed = it.minusMonths(1), tilOgMed = it)
+        lagAndelTilkjentYtelse(beløp = 0, fraOgMed = it.minusMonths(1), tilOgMed = it, inntekt = 200_000)
     },
 ): IverksettOvergangsstønad {
     val behandlingÅrsak = if (erMigrering) BehandlingÅrsak.MIGRERING else årsak

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
@@ -195,7 +195,7 @@ fun lagIverksettData(
             vedtaksresultat = vedtaksresultat,
             vedtaksperioder = vedtaksperioder,
             andeler = andelsdatoer.map {
-                lagAndelTilkjentYtelse(beløp = 0, fraOgMed = it.minusMonths(1), tilOgMed = it)
+                lagAndelTilkjentYtelse(beløp = 0, fraOgMed = it.minusMonths(1), tilOgMed = it, inntekt = 200_000)
             },
             startdato = andelsdatoer.minByOrNull { it } ?: YearMonth.now(),
         ),

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
@@ -1,0 +1,24 @@
+package no.nav.familie.ef.iverksett.brukernotifikasjon
+
+import io.mockk.mockk
+import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
+import no.nav.brukernotifikasjon.schemas.input.NokkelInput
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.kafka.core.KafkaTemplate
+import java.time.YearMonth
+
+class BrukernotifikasjonKafkaProducerTest {
+
+    private val kafkaTemplate = mockk<KafkaTemplate<NokkelInput, BeskjedInput>>()
+    private val brukernotifikasjonKafkaProducer = BrukernotifikasjonKafkaProducer(kafkaTemplate)
+
+    private val forventetGOmregningTekst = """
+        Folketrygdens grunnbeløp er økt til <Nytt G-beløp> kroner pr. år fra 1. mai ${YearMonth.now().year}. Ytelsen er derfor omregnet.
+    """.trimIndent()
+
+    @Test
+    fun `lagBeskjed genererer riktig melding`() {
+        Assertions.assertThat(brukernotifikasjonKafkaProducer.lagBeskjed().getTekst()).isEqualTo(forventetGOmregningTekst)
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
@@ -3,6 +3,10 @@ package no.nav.familie.ef.iverksett.brukernotifikasjon
 import io.mockk.mockk
 import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
 import no.nav.brukernotifikasjon.schemas.input.NokkelInput
+import no.nav.familie.ef.iverksett.iverksetting.domene.IverksettData
+import no.nav.familie.ef.iverksett.lagIverksettData
+import no.nav.familie.kontrakter.ef.felles.BehandlingType
+import no.nav.familie.kontrakter.ef.felles.Vedtaksresultat
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.kafka.core.KafkaTemplate
@@ -12,13 +16,16 @@ class BrukernotifikasjonKafkaProducerTest {
 
     private val kafkaTemplate = mockk<KafkaTemplate<NokkelInput, BeskjedInput>>()
     private val brukernotifikasjonKafkaProducer = BrukernotifikasjonKafkaProducer(kafkaTemplate)
-
+    private val iverksett = mockk<IverksettData>()
     private val forventetGOmregningTekst = """
-        Folketrygdens grunnbeløp er økt til <Nytt G-beløp> kroner pr. år fra 1. mai ${YearMonth.now().year}. Ytelsen er derfor omregnet.
+        Fra ${nyesteGrunnbeløp.periode.fomDato.norskFormat()} har folketrygdens grunnbeløp økt til ${nyesteGrunnbeløp.grunnbeløp} kroner og din forventede inntekt er oppjustert til 200000 kroner. Overgangsstønaden din er derfor endret.
+        Du må si ifra til oss hvis inntekten din øker eller reduseres med 10 prosent eller mer.
     """.trimIndent()
 
     @Test
     fun `lagBeskjed genererer riktig melding`() {
-        Assertions.assertThat(brukernotifikasjonKafkaProducer.lagBeskjed().getTekst()).isEqualTo(forventetGOmregningTekst)
+        val iverksettRevurderingInnvilget = lagIverksettData(behandlingType = BehandlingType.REVURDERING, vedtaksresultat = Vedtaksresultat.INNVILGET, andelsdatoer = listOf(
+            YearMonth.now().minusMonths(1), YearMonth.now()))
+        Assertions.assertThat(brukernotifikasjonKafkaProducer.lagBeskjed(iverksettRevurderingInnvilget).getTekst()).isEqualTo(forventetGOmregningTekst)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
@@ -24,8 +24,14 @@ class BrukernotifikasjonKafkaProducerTest {
 
     @Test
     fun `lagBeskjed genererer riktig melding`() {
-        val iverksettRevurderingInnvilget = lagIverksettData(behandlingType = BehandlingType.REVURDERING, vedtaksresultat = Vedtaksresultat.INNVILGET, andelsdatoer = listOf(
-            YearMonth.now().minusMonths(1), YearMonth.now()))
+        val iverksettRevurderingInnvilget = lagIverksettData(
+            behandlingType = BehandlingType.REVURDERING,
+            vedtaksresultat = Vedtaksresultat.INNVILGET,
+            andelsdatoer = listOf(
+                YearMonth.now().minusMonths(1),
+                YearMonth.now(),
+            ),
+        )
         Assertions.assertThat(brukernotifikasjonKafkaProducer.lagBeskjed(iverksettRevurderingInnvilget).getTekst()).isEqualTo(forventetGOmregningTekst)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
@@ -27,8 +27,8 @@ class BrukernotifikasjonKafkaProducerTest {
             behandlingType = BehandlingType.REVURDERING,
             vedtaksresultat = Vedtaksresultat.INNVILGET,
             andelsdatoer = listOf(
-                YearMonth.now().minusMonths(1),
                 YearMonth.now(),
+                YearMonth.now().plusMonths(1),
             ),
         )
         Assertions.assertThat(brukernotifikasjonKafkaProducer.lagBeskjed(iverksettRevurderingInnvilget).getTekst()).isEqualTo(forventetGOmregningTekst)

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ef.iverksett.brukernotifikasjon
 import io.mockk.mockk
 import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
 import no.nav.brukernotifikasjon.schemas.input.NokkelInput
-import no.nav.familie.ef.iverksett.iverksetting.domene.IverksettData
 import no.nav.familie.ef.iverksett.lagIverksettData
 import no.nav.familie.kontrakter.ef.felles.BehandlingType
 import no.nav.familie.kontrakter.ef.felles.Vedtaksresultat
@@ -16,7 +15,7 @@ class BrukernotifikasjonKafkaProducerTest {
 
     private val kafkaTemplate = mockk<KafkaTemplate<NokkelInput, BeskjedInput>>()
     private val brukernotifikasjonKafkaProducer = BrukernotifikasjonKafkaProducer(kafkaTemplate)
-    private val iverksett = mockk<IverksettData>()
+
     private val forventetGOmregningTekst = """
         Fra ${nyesteGrunnbeløp.periode.fomDato.norskFormat()} har folketrygdens grunnbeløp økt til ${nyesteGrunnbeløp.grunnbeløp} kroner og din forventede inntekt er oppjustert til 200000 kroner. Overgangsstønaden din er derfor endret.
         Du må si ifra til oss hvis inntekten din øker eller reduseres med 10 prosent eller mer.

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTaskTest.kt
@@ -3,29 +3,42 @@ package no.nav.familie.ef.iverksett.brukernotifikasjon
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.runs
+import io.mockk.unmockkObject
 import io.mockk.verify
 import no.nav.familie.ef.iverksett.infrastruktur.transformer.toDomain
 import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
 import no.nav.familie.ef.iverksett.lagIverksett
 import no.nav.familie.ef.iverksett.repository.findByIdOrThrow
+import no.nav.familie.ef.iverksett.util.mockFeatureToggleService
 import no.nav.familie.ef.iverksett.util.opprettIverksettDto
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.prosessering.domene.Task
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 import java.util.UUID
 
 class SendBrukernotifikasjonVedGOmregningTaskTest {
 
     private val iverksettingRepository = mockk<IverksettingRepository>()
     private val brukernotifikasjonKafkaProducer = mockk<BrukernotifikasjonKafkaProducer>()
-    private val task = SendBrukernotifikasjonVedGOmregningTask(brukernotifikasjonKafkaProducer, iverksettingRepository)
+    private val task = SendBrukernotifikasjonVedGOmregningTask(brukernotifikasjonKafkaProducer, iverksettingRepository, mockFeatureToggleService())
 
     @BeforeEach
     internal fun setUp() {
+        mockkObject(DatoUtil)
         every { iverksettingRepository.findByIdOrThrow(any()) }
             .returns(lagIverksett(opprettIverksettDto(behandlingId = UUID.randomUUID(), behandlingÅrsak = BehandlingÅrsak.G_OMREGNING).toDomain()))
+
+        every { DatoUtil.dagensDato() } returns LocalDate.of(2023, 3, 1)
+    }
+
+    @AfterEach
+    internal fun tearDown() {
+        unmockkObject(DatoUtil)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTaskTest.kt
@@ -1,0 +1,38 @@
+package no.nav.familie.ef.iverksett.brukernotifikasjon
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import no.nav.familie.ef.iverksett.infrastruktur.transformer.toDomain
+import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
+import no.nav.familie.ef.iverksett.lagIverksett
+import no.nav.familie.ef.iverksett.repository.findByIdOrThrow
+import no.nav.familie.ef.iverksett.util.opprettIverksettDto
+import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
+import no.nav.familie.prosessering.domene.Task
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class SendBrukernotifikasjonVedGOmregningTaskTest {
+
+    private val iverksettingRepository = mockk<IverksettingRepository>()
+    private val brukernotifikasjonKafkaProducer = mockk<BrukernotifikasjonKafkaProducer>()
+    private val task = SendBrukernotifikasjonVedGOmregningTask(brukernotifikasjonKafkaProducer, iverksettingRepository)
+
+    @BeforeEach
+    internal fun setUp() {
+        every { iverksettingRepository.findByIdOrThrow(any()) }
+            .returns(lagIverksett(opprettIverksettDto(behandlingId = UUID.randomUUID(), behandlingÅrsak = BehandlingÅrsak.G_OMREGNING).toDomain()))
+    }
+
+    @Test
+    internal fun `doTask - skal publisere vedtak til kafka`() {
+        every { brukernotifikasjonKafkaProducer.sendBeskjedTilBruker(any(), any()) } just runs
+        task.doTask(Task(SendBrukernotifikasjonVedGOmregningTask.TYPE, UUID.randomUUID().toString()))
+
+        verify(exactly = 1) { brukernotifikasjonKafkaProducer.sendBeskjedTilBruker(any(), any()) }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskTypeTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskTypeTest.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ef.iverksett.arbeidsoppfolging.SendVedtakTilArbeidsoppføl
 import no.nav.familie.ef.iverksett.arena.SendFattetVedtakTilArenaTask
 import no.nav.familie.ef.iverksett.brev.DistribuerVedtaksbrevTask
 import no.nav.familie.ef.iverksett.brev.JournalførVedtaksbrevTask
+import no.nav.familie.ef.iverksett.brukernotifikasjon.SendBrukernotifikasjonVedGOmregningTask
 import no.nav.familie.ef.iverksett.infotrygd.SendFattetVedtakTilInfotrygdTask
 import no.nav.familie.ef.iverksett.infotrygd.SendPerioderTilInfotrygdTask
 import no.nav.familie.ef.iverksett.oppgave.OpprettOppfølgingsOppgaveForOvergangsstønadTask
@@ -71,6 +72,10 @@ class TaskTypeTest {
         val vedtaksstatistikkTask = opprettOppgaveTask.opprettNestePubliseringTask()
         assertThat(vedtaksstatistikkTask.type).isEqualTo(VedtakstatistikkTask.TYPE)
         assertThat(vedtaksstatistikkTask.triggerTid).isBefore(LocalDateTime.now().plusMinutes(1))
+
+        val sendBrukernotifikasjonVedGOmregningTask = vedtaksstatistikkTask.opprettNestePubliseringTask()
+        assertThat(sendBrukernotifikasjonVedGOmregningTask.type).isEqualTo(SendBrukernotifikasjonVedGOmregningTask.TYPE)
+        assertThat(sendBrukernotifikasjonVedGOmregningTask.triggerTid).isBefore(LocalDateTime.now().plusMinutes(1))
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/vedtak/PubliserVedtakTilKafkaTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/vedtak/PubliserVedtakTilKafkaTaskTest.kt
@@ -39,7 +39,7 @@ internal class PubliserVedtakTilKafkaTaskTest {
     }
 
     @Test
-    internal fun `doTask - ska publisere vedtak til kafka`() {
+    internal fun `doTask - skal publisere vedtak til kafka`() {
         every { vedtakKafkaProducer.sendVedtak(any()) } just runs
         task.doTask(lagTask())
 

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkTaskTest.kt
@@ -1,29 +1,42 @@
 package no.nav.familie.ef.iverksett.vedtakstatistikk
 
+import io.mockk.CapturingSlot
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.familie.ef.iverksett.brukernotifikasjon.SendBrukernotifikasjonVedGOmregningTask
 import no.nav.familie.ef.iverksett.infrastruktur.transformer.toDomain
 import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
-import no.nav.familie.ef.iverksett.iverksetting.tilstand.IverksettResultatService
 import no.nav.familie.ef.iverksett.lagIverksett
 import no.nav.familie.ef.iverksett.repository.findByIdOrThrow
 import no.nav.familie.ef.iverksett.util.opprettIverksettDto
+import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.internal.TaskService
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.Properties
 import java.util.UUID
 
 internal class VedtakstatistikkTaskTest {
 
-    val iverksettingRepository = mockk<IverksettingRepository>()
+    private val iverksettingRepository = mockk<IverksettingRepository>()
     private val vedtakstatistikkService = mockk<VedtakstatistikkService>()
-    val iverksettResultatService = mockk<IverksettResultatService>()
+    private val taskService = mockk<TaskService>()
     private val vedtakstatistikkTask =
-        VedtakstatistikkTask(iverksettingRepository, vedtakstatistikkService)
-    val behandlingId: UUID = UUID.randomUUID()
+        VedtakstatistikkTask(iverksettingRepository, vedtakstatistikkService, taskService)
+    private val taskSlot = CapturingSlot<Task>()
+    private val behandlingId: UUID = UUID.randomUUID()
+
+    @BeforeEach
+    internal fun setUp() {
+        every { iverksettingRepository.findByIdOrThrow(any()) }
+            .returns(lagIverksett(opprettIverksettDto(behandlingId = UUID.randomUUID()).toDomain()))
+        every { taskService.save(capture(taskSlot)) } answers { firstArg() }
+    }
 
     @Test
     fun `skal sende vedtaksstatistikk til DVH`() {
@@ -36,5 +49,21 @@ internal class VedtakstatistikkTaskTest {
 
         vedtakstatistikkTask.doTask(Task(VedtakstatistikkTask.TYPE, behandlingIdString, Properties()))
         verify(exactly = 1) { vedtakstatistikkService.sendTilKafka(returnIverksetting.data, null) }
+    }
+
+    @Test
+    internal fun `onCompletion - skal opprette neste task hvis G-omregning`() {
+        every { iverksettingRepository.findByIdOrThrow(any()) }
+            .returns(lagIverksett(opprettIverksettDto(behandlingId = UUID.randomUUID(), behandlingÅrsak = BehandlingÅrsak.G_OMREGNING).toDomain()))
+        vedtakstatistikkTask.onCompletion(Task(VedtakstatistikkTask.TYPE, UUID.randomUUID().toString()))
+
+        verify(exactly = 1) { taskService.save(any()) }
+        Assertions.assertThat(taskSlot.captured.type).isEqualTo(SendBrukernotifikasjonVedGOmregningTask.TYPE)
+    }
+
+    @Test
+    internal fun `onCompletion - skal ikke opprette neste task hvis ikke G-omregning`() {
+        vedtakstatistikkTask.onCompletion(Task(VedtakstatistikkTask.TYPE, UUID.randomUUID().toString()))
+        verify(exactly = 0) { taskService.save(any()) }
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkTaskTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ef.iverksett.infrastruktur.transformer.toDomain
 import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
 import no.nav.familie.ef.iverksett.lagIverksett
 import no.nav.familie.ef.iverksett.repository.findByIdOrThrow
+import no.nav.familie.ef.iverksett.util.mockFeatureToggleService
 import no.nav.familie.ef.iverksett.util.opprettIverksettDto
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.prosessering.domene.Task
@@ -27,7 +28,7 @@ internal class VedtakstatistikkTaskTest {
     private val vedtakstatistikkService = mockk<VedtakstatistikkService>()
     private val taskService = mockk<TaskService>()
     private val vedtakstatistikkTask =
-        VedtakstatistikkTask(iverksettingRepository, vedtakstatistikkService, taskService)
+        VedtakstatistikkTask(iverksettingRepository, vedtakstatistikkService, taskService, mockFeatureToggleService())
     private val taskSlot = CapturingSlot<Task>()
     private val behandlingId: UUID = UUID.randomUUID()
 

--- a/src/test/resources/application-servertest.yml
+++ b/src/test/resources/application-servertest.yml
@@ -52,3 +52,6 @@ KAFKA_BROKERS: hostname:1234
 KAFKA_KEYSTORE_PATH: kafkaKeystorePath
 KAFKA_CREDSTORE_PASSWORD: kafkaCredstorePassword
 KAFKA_TRUSTSTORE_PATH: kafkaTruststorePath
+KAFKA_SCHEMA_REGISTRY: kafkaSchemaRegistry
+KAFKA_SCHEMA_REGISTRY_USER: kafkaSchemaRegistryUser
+KAFKA_SCHEMA_REGISTRY_PASSWORD: kafkaSchemaRegistryPassword


### PR DESCRIPTION
I fjor måtte vi manuelt sende en fil på gitt format til Økonomi for å kunne gi en beskjed til bruker om at vedtaket er G-omregnet. I år kan vi gjøre dette selv ved å sende melding på kafka-topic til brukernotifikasjoner i stedet. Dersom behandlingÅrsak er G-omregning opprettes en sendBrukernotifikasjonTask som publiserer en brukernotifikasjon-hendelse på kafka.
[Link til brukernotifikasjoner dokumentasjon](https://navikt.github.io/brukernotifikasjon-docs/eventtyper/fellesinfo/)

Testet i dev at `SendBrukernotifikasjonVedGOmregningTask` ikke blir opprettet for "vanlige" vedtak som ikke er g-omregning.

🚧 Tekst er ikke avklart enda, venter med å merge til tekst er klar

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12304)