### PR TITLE
Skille på oppfølgingsenhet og fremleggsoppgave ved tilordning av enhetId

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveService.kt
@@ -53,7 +53,7 @@ class OppgaveService(
         }
     }
 
-    fun opprettOppgave(iverksett: IverksettOvergangsstønad, oppgaveType: Oppgavetype, beskrivelse: String): Long {
+    fun opprettOppgaveMedOppfølgingsenhet(iverksett: IverksettOvergangsstønad, oppgaveType: Oppgavetype, beskrivelse: String): Long {
         val enhet = familieIntegrasjonerClient.hentBehandlendeEnhetForOppfølging(iverksett.søker.personIdent)
             ?: error("Kunne ikke finne enhetsnummer for personident med behandlingsId=${iverksett.behandling.behandlingId}")
 
@@ -62,11 +62,28 @@ class OppgaveService(
                 eksternFagsakId = iverksett.fagsak.eksternId,
                 personIdent = iverksett.søker.personIdent,
                 stønadstype = iverksett.fagsak.stønadstype,
-                enhetsnummer = enhet,
+                enhetId = enhet.enhetId,
                 oppgavetype = oppgaveType,
                 beskrivelse = beskrivelse,
                 settBehandlesAvApplikasjon = false,
-                mappeId = finnMappeHvisFremleggsoppgave(iverksett.søker.tilhørendeEnhet, oppgaveType, iverksett.behandling.behandlingId),
+                mappeId = null,
+            )
+
+        return oppgaveClient.opprettOppgave(opprettOppgaveRequest)?.let { return it }
+            ?: error("Kunne ikke finne oppgave for behandlingId=${iverksett.behandling.behandlingId}")
+    }
+
+    fun opprettFremleggsoppgave(iverksett: IverksettOvergangsstønad, beskrivelse: String): Long {
+        val opprettOppgaveRequest =
+            OppgaveUtil.opprettOppgaveRequest(
+                eksternFagsakId = iverksett.fagsak.eksternId,
+                personIdent = iverksett.søker.personIdent,
+                stønadstype = iverksett.fagsak.stønadstype,
+                enhetId = iverksett.søker.tilhørendeEnhet,
+                oppgavetype = Oppgavetype.Fremlegg,
+                beskrivelse = beskrivelse,
+                settBehandlesAvApplikasjon = false,
+                mappeId = finnMappeHvisFremleggsoppgave(iverksett.søker.tilhørendeEnhet, Oppgavetype.Fremlegg, iverksett.behandling.behandlingId),
             )
 
         return oppgaveClient.opprettOppgave(opprettOppgaveRequest)?.let { return it }
@@ -82,7 +99,7 @@ class OppgaveService(
 
     private fun finnMappeHvisFremleggsoppgave(enhetsnummer: String?, oppgavetype: Oppgavetype, behandlingId: UUID): Long? {
         if (enhetsnummer == "4489" && oppgavetype == Oppgavetype.Fremlegg) {
-            val mappenavnProd = "41 Revurdering";
+            val mappenavnProd = "41 Revurdering"
             val mappenavnDev = "41 - Revurdering"
             val mapper = finnMapper(enhetsnummer)
             val mappeIdForFremleggsoppgave = mapper.find { it.navn.contains(mappenavnDev) || it.navn.contains(mappenavnProd) }?.id?.toLong()

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveService.kt
@@ -82,7 +82,7 @@ class OppgaveService(
                 oppgavetype = Oppgavetype.Fremlegg,
                 beskrivelse = beskrivelse,
                 settBehandlesAvApplikasjon = false,
-                mappeId = finnMappeHvisFremleggsoppgave(iverksett.søker.tilhørendeEnhet, Oppgavetype.Fremlegg, iverksett.behandling.behandlingId),
+                mappeId = finnMappeForFremleggsoppgave(iverksett.søker.tilhørendeEnhet, iverksett.behandling.behandlingId),
             )
 
         return oppgaveClient.opprettOppgave(opprettOppgaveRequest)?.let { return it }
@@ -96,8 +96,8 @@ class OppgaveService(
             else -> error("Kunne ikke finne riktig BehandlingType for oppfølgingsoppgave")
         }
 
-    private fun finnMappeHvisFremleggsoppgave(enhetsnummer: String?, oppgavetype: Oppgavetype, behandlingId: UUID): Long? {
-        if (enhetsnummer == "4489" && oppgavetype == Oppgavetype.Fremlegg) {
+    private fun finnMappeForFremleggsoppgave(enhetsnummer: String?, behandlingId: UUID): Long? {
+        if (enhetsnummer == "4489") {
             val mappenavnProd = "41 Revurdering"
             val mappenavnDev = "41 - Revurdering"
             val mapper = finnMapper(enhetsnummer)

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveService.kt
@@ -66,7 +66,6 @@ class OppgaveService(
                 oppgavetype = oppgaveType,
                 beskrivelse = beskrivelse,
                 settBehandlesAvApplikasjon = false,
-                mappeId = null,
             )
 
         return oppgaveClient.opprettOppgave(opprettOppgaveRequest)?.let { return it }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveUtil.kt
@@ -33,7 +33,7 @@ object OppgaveUtil {
         beskrivelse: String,
         settBehandlesAvApplikasjon: Boolean,
         fristFerdigstillelse: LocalDate? = null,
-        mappeId: Long?,
+        mappeId: Long? = null,
     ): OpprettOppgaveRequest {
         return OpprettOppgaveRequest(
             ident = OppgaveIdentV2(ident = personIdent, gruppe = IdentGruppe.FOLKEREGISTERIDENT),

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveUtil.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.iverksett.oppgave
 
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Tema
-import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveIdentV2
@@ -29,7 +28,7 @@ object OppgaveUtil {
         eksternFagsakId: Long,
         personIdent: String,
         stønadstype: StønadType,
-        enhetsnummer: Enhet,
+        enhetId: String,
         oppgavetype: Oppgavetype,
         beskrivelse: String,
         settBehandlesAvApplikasjon: Boolean,
@@ -43,7 +42,7 @@ object OppgaveUtil {
             oppgavetype = oppgavetype,
             fristFerdigstillelse = fristFerdigstillelse(fristFerdigstillelse),
             beskrivelse = beskrivelse,
-            enhetsnummer = enhetsnummer.enhetId,
+            enhetsnummer = enhetId,
             behandlingstema = opprettBehandlingstema(stønadstype).value,
             tilordnetRessurs = null,
             behandlesAvApplikasjon = if (settBehandlesAvApplikasjon) "familie-ef-sak" else null,

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OpprettFremleggsoppgaveForOvergangsstønadTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OpprettFremleggsoppgaveForOvergangsstønadTask.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
 import no.nav.familie.ef.iverksett.iverksetting.domene.IverksettOvergangsstønad
 import no.nav.familie.ef.iverksett.repository.findByIdOrThrow
 import no.nav.familie.kontrakter.ef.iverksett.OppgaveForOpprettelseType
-import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
@@ -38,7 +37,7 @@ class OpprettFremleggsoppgaveForOvergangsstønadTask(
             return
         }
         if (iverksett.data.vedtak.oppgaverForOpprettelse.oppgavetyper.contains(OppgaveForOpprettelseType.INNTEKTSKONTROLL_1_ÅR_FREM_I_TID)) {
-            val oppgaveId = oppgaveService.opprettOppgave(iverksett.data, Oppgavetype.Fremlegg, "Inntekt")
+            val oppgaveId = oppgaveService.opprettFremleggsoppgave(iverksett.data, "Inntekt")
             logger.info("Opprettet oppgave for behandling=$behandlingId oppgave=$oppgaveId")
         } else {
             logger.info("Oppgave opprettes ikke for behandling=$behandlingId")

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OpprettOppfølgingsOppgaveForOvergangsstønadTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OpprettOppfølgingsOppgaveForOvergangsstønadTask.kt
@@ -38,7 +38,7 @@ class OpprettOppfølgingsOppgaveForOvergangsstønadTask(
         }
 
         if (oppgaveService.skalOppretteVurderHenvendelseOppgave(iverksett.data)) {
-            val oppgaveId = oppgaveService.opprettOppgave(
+            val oppgaveId = oppgaveService.opprettOppgaveMedOppfølgingsenhet(
                 iverksett.data,
                 Oppgavetype.VurderHenvendelse,
                 oppgaveService.lagOppgavebeskrivelseForVurderHenvendelseOppgave(iverksett.data),

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveServiceTest.kt
@@ -19,6 +19,7 @@ import no.nav.familie.kontrakter.ef.felles.Vedtaksresultat
 import no.nav.familie.kontrakter.ef.iverksett.AktivitetType
 import no.nav.familie.kontrakter.ef.iverksett.VedtaksperiodeType
 import no.nav.familie.kontrakter.felles.Månedsperiode
+import no.nav.familie.kontrakter.felles.arbeidsfordeling.Enhet
 import no.nav.familie.kontrakter.felles.oppgave.FinnMappeResponseDto
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import org.assertj.core.api.Assertions.assertThat
@@ -44,6 +45,7 @@ internal class OppgaveServiceTest {
         every { oppgaveClient.opprettOppgave(any()) } returns 0L
         every { OppgaveUtil.opprettOppgaveRequest(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns mockk()
         every { oppgaveClient.finnMapper(any(), any()) } returns FinnMappeResponseDto(0, emptyList())
+        every { familieIntegrasjonerClient.hentBehandlendeEnhetForOppfølging(any()) } returns Enhet("1234", "enhet")
     }
 
     @AfterEach
@@ -159,7 +161,7 @@ internal class OppgaveServiceTest {
             listOf(vedtaksPeriode(aktivitet = AktivitetType.IKKE_AKTIVITETSPLIKT)),
         )
 
-        oppgaveService.opprettOppgave(
+        oppgaveService.opprettOppgaveMedOppfølgingsenhet(
             iverksett,
             Oppgavetype.VurderHenvendelse,
             oppgaveService.lagOppgavebeskrivelseForVurderHenvendelseOppgave(iverksett),
@@ -253,7 +255,7 @@ internal class OppgaveServiceTest {
             listOf(vedtaksPeriode(aktivitet = AktivitetType.FORSØRGER_I_ARBEID)),
         )
 
-        oppgaveService.opprettOppgave(
+        oppgaveService.opprettOppgaveMedOppfølgingsenhet(
             iverksett,
             Oppgavetype.VurderHenvendelse,
             oppgaveService.lagOppgavebeskrivelseForVurderHenvendelseOppgave(iverksett),
@@ -270,7 +272,7 @@ internal class OppgaveServiceTest {
             listOf(vedtaksPeriode(aktivitet = AktivitetType.FORSØRGER_I_ARBEID)),
         )
 
-        oppgaveService.opprettOppgave(
+        oppgaveService.opprettOppgaveMedOppfølgingsenhet(
             iverksett,
             Oppgavetype.VurderHenvendelse,
             oppgaveService.lagOppgavebeskrivelseForVurderHenvendelseOppgave(iverksett),
@@ -287,7 +289,7 @@ internal class OppgaveServiceTest {
             listOf(vedtaksPeriode(aktivitet = AktivitetType.FORSØRGER_I_ARBEID)),
         )
 
-        oppgaveService.opprettOppgave(
+        oppgaveService.opprettOppgaveMedOppfølgingsenhet(
             iverksett,
             Oppgavetype.VurderHenvendelse,
             oppgaveService.lagOppgavebeskrivelseForVurderHenvendelseOppgave(iverksett),
@@ -315,7 +317,7 @@ internal class OppgaveServiceTest {
             andelsdatoer = listOf(YearMonth.now()),
         )
 
-        oppgaveService.opprettOppgave(
+        oppgaveService.opprettOppgaveMedOppfølgingsenhet(
             iverksett,
             Oppgavetype.VurderHenvendelse,
             oppgaveService.lagOppgavebeskrivelseForVurderHenvendelseOppgave(iverksett),
@@ -334,7 +336,7 @@ internal class OppgaveServiceTest {
             andelsdatoer = listOf(YearMonth.now().minusMonths(2), YearMonth.now(), YearMonth.now().minusMonths(1)),
         )
 
-        oppgaveService.opprettOppgave(
+        oppgaveService.opprettOppgaveMedOppfølgingsenhet(
             iverksett,
             Oppgavetype.VurderHenvendelse,
             oppgaveService.lagOppgavebeskrivelseForVurderHenvendelseOppgave(iverksett),

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaverForOpprettelseForOvergangsstønadTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaverForOpprettelseForOvergangsstønadTaskTest.kt
@@ -10,7 +10,6 @@ import no.nav.familie.ef.iverksett.repository.findByIdOrThrow
 import no.nav.familie.ef.iverksett.util.opprettIverksettBarnetilsyn
 import no.nav.familie.ef.iverksett.util.opprettIverksettOvergangsstønad
 import no.nav.familie.ef.iverksett.util.vedtaksdetaljerOvergangsstønad
-import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import org.junit.jupiter.api.Test
@@ -30,11 +29,11 @@ class OppgaverForOpprettelseForOvergangsstønadTaskTest {
     @Test
     internal fun `skal opprette fremleggsoppgave for overgangsstønad`() {
         every { iverksettingRepository.findByIdOrThrow(any()) } returns lagIverksett(opprettIverksettOvergangsstønad())
-        every { oppgaveService.opprettOppgave(any(), Oppgavetype.Fremlegg, any()) } returns 1
+        every { oppgaveService.opprettFremleggsoppgave(any(), any()) } returns 1
 
         taskStegService.doTask(opprettTask())
 
-        verify(exactly = 1) { oppgaveService.opprettOppgave(any(), Oppgavetype.Fremlegg, any()) }
+        verify(exactly = 1) { oppgaveService.opprettFremleggsoppgave(any(), any()) }
     }
 
     @Test
@@ -48,11 +47,11 @@ class OppgaverForOpprettelseForOvergangsstønadTaskTest {
                 ),
             ),
         )
-        every { oppgaveService.opprettOppgave(any(), Oppgavetype.Fremlegg, any()) } returns 1
+        every { oppgaveService.opprettFremleggsoppgave(any(), any()) } returns 1
 
         taskStegService.doTask(opprettTask())
 
-        verify(exactly = 0) { oppgaveService.opprettOppgave(any(), Oppgavetype.Fremlegg, any()) }
+        verify(exactly = 0) { oppgaveService.opprettFremleggsoppgave(any(), any()) }
     }
 
     @Test
@@ -61,7 +60,7 @@ class OppgaverForOpprettelseForOvergangsstønadTaskTest {
 
         taskStegService.doTask(opprettTask())
 
-        verify(exactly = 0) { oppgaveService.opprettOppgave(any(), Oppgavetype.Fremlegg, any()) }
+        verify(exactly = 0) { oppgaveService.opprettFremleggsoppgave(any(), any()) }
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/oppgave/OpprettOppfølgingsOppgaveForOvergangsstønadTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/oppgave/OpprettOppfølgingsOppgaveForOvergangsstønadTaskTest.kt
@@ -30,14 +30,14 @@ internal class OpprettOppfølgingsOppgaveForOvergangsstønadTaskTest {
     internal fun `skal opprette oppfølgningsoppgave for overgangsstønad`() {
         every { iverksettingRepository.findByIdOrThrow(any()) } returns lagIverksett(opprettIverksettOvergangsstønad())
         every { oppgaveService.skalOppretteVurderHenvendelseOppgave(any()) } returns true
-        every { oppgaveService.opprettOppgave(any(), Oppgavetype.VurderHenvendelse, any()) } returns 1
+        every { oppgaveService.opprettOppgaveMedOppfølgingsenhet(any(), Oppgavetype.VurderHenvendelse, any()) } returns 1
         every { oppgaveService.lagOppgavebeskrivelseForVurderHenvendelseOppgave(any()) } returns "Beskrivelse"
 
         taskStegService.doTask(opprettTask())
 
         verify(exactly = 1) { oppgaveService.skalOppretteVurderHenvendelseOppgave(any()) }
         verify(exactly = 1) {
-            oppgaveService.opprettOppgave(
+            oppgaveService.opprettOppgaveMedOppfølgingsenhet(
                 any(),
                 Oppgavetype.VurderHenvendelse,
                 any(),


### PR DESCRIPTION
Hvorfor ? 

Trenger å skille på opprettelse av oppgaver som skal sendes til oppfølging og opprettelse av fremleggsoppgaver som skal opprettes sentralt. 