### PR TITLE
dersom startdatoen endres tilbake i tid fra førstegangsbehandlingen m…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -35,7 +35,13 @@ object UtbetalingsoppdragGenerator {
         val andelerForrigeTilkjentYtelse = andelerUtenNullVerdier(forrigeTilkjentYtelse)
         val sistePeriodeIdIForrigeKjede = sistePeriodeId(forrigeTilkjentYtelse)
 
-        val beståendeAndeler = beståendeAndeler(andelerForrigeTilkjentYtelse, andelerNyTilkjentYtelse)
+        val beståendeAndeler = beståendeAndeler(
+            andelerForrigeTilkjentYtelse,
+            andelerNyTilkjentYtelse,
+            nyTilkjentYtelse.startmåned,
+            forrigeTilkjentYtelse?.startmåned
+        )
+
         val andelerTilOpprettelse = andelerTilOpprettelse(andelerNyTilkjentYtelse, beståendeAndeler)
 
         val andelerTilOpprettelseMedPeriodeId = lagAndelerMedPeriodeId(
@@ -143,7 +149,7 @@ object UtbetalingsoppdragGenerator {
     private fun sistePeriodeId(tilkjentYtelse: TilkjentYtelse?): PeriodeId? {
         return tilkjentYtelse?.let { ytelse ->
             ytelse.sisteAndelIKjede?.tilPeriodeId()
-                // TODO denne kan fjernes når den er patchet
+            // TODO denne kan fjernes når den er patchet
                 ?: ytelse.andelerTilkjentYtelse.filter { it.periodeId != null }.maxByOrNull { it.periodeId!! }?.tilPeriodeId()
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/ØkonomiUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/ØkonomiUtils.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ef.iverksett.iverksetting.domene.TilkjentYtelseMedMetaData
 import no.nav.familie.kontrakter.felles.Månedsperiode
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
 import java.time.LocalDate
+import java.time.YearMonth
 import java.util.UUID
 
 data class PeriodeId(
@@ -40,14 +41,20 @@ object ØkonomiUtils {
      * Vi må opphøre og eventuelt gjenoppbygge hver kjede etter denne. Må ta vare på andel og ikke kun offset da
      * filtrering av oppdaterte andeler senere skjer før offset blir satt.
      *
-     * @param[andelerForrigeTilkjentYtelse] forrige behandlings tilstand
+     * @param[andelerForrigeTilkjentYtelse] forrige behandlingstilstand
      * @param[andelerNyTilkjentYtelse] nåværende tilstand
      * @return liste med bestående andeler
      */
     fun beståendeAndeler(
         andelerForrigeTilkjentYtelse: List<AndelTilkjentYtelse>,
         andelerNyTilkjentYtelse: List<AndelTilkjentYtelse>,
+        nyStartDato: YearMonth,
+        forrigeStartDato: YearMonth?,
     ): List<AndelTilkjentYtelse> {
+        if (forrigeStartDato != null && nyStartDato.isBefore(forrigeStartDato)) {
+            return emptyList()
+        }
+
         val forrigeAndeler = andelerForrigeTilkjentYtelse.toSet()
         val oppdaterteAndeler = andelerNyTilkjentYtelse.toSet()
 

--- a/src/test/resources/no/nav/familie/ef/iverksett/cucumber/oppdrag/startdato_endrer_seg_like_andeler.feature
+++ b/src/test/resources/no/nav/familie/ef/iverksett/cucumber/oppdrag/startdato_endrer_seg_like_andeler.feature
@@ -1,0 +1,23 @@
+# language: no
+# encoding: UTF-8
+Egenskap: Startdato endrer seg men andelene blir de samme
+
+  Scenario: Startdato endrer seg over et år tilbake i tid men andelene blir de samme
+
+    Gitt følgende startdatoer
+      | BehandlingId | Startdato |
+      | 1            | 03.2021   |
+      | 2            | 02.2020   |
+
+    Og følgende tilkjente ytelser for Overgangsstønad
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 03.2021  | 700   |
+      | 2            | 03.2021  | 03.2021  | 700   |
+
+    Når lagTilkjentYtelseMedUtbetalingsoppdrag kjøres
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 1          |                    |
+      | 2            | 03.2021  | 03.2021  | 02.2020     | 700   | ENDR         | Ja         | 1          |                    |
+      | 2            | 03.2021  | 03.2021  |             | 700   | ENDR         | Nei        | 2          | 1                  |


### PR DESCRIPTION
…en andelene forblir like i revurderingen skal de utbetalte periodene også forbli like

Testet i dev ✅ 

Tilknyttet [dette favro kortet](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12530) og [denne slack-tråden](https://nav-it.slack.com/archives/G012YEK9YQ1/p1683815920869459)

Dersom man oppretter en revurdering og endrer startdato for utbetaling tilbake i tid men har like andeler som i førstegangsbehandlingen blir vedtaket tolket som ET opphør som strekker seg over alle andelsperiodene. 

Forventet oppførsel her hadde vært om andelsperiodene i revurderingen forble identiske som andelsperiodene i førstegangsbehandlingen.  Det er dette denne PRen skal løse.

