### PR TITLE
Brev karakterutskrift journalføring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <kotlin.version>1.8.21</kotlin.version>
         <springdoc.version>2.1.0</springdoc.version>
         <felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
-        <familie.kontrakter.version>3.0_20230404163639_edb8619-JAKARTA</familie.kontrakter.version>
+        <familie.kontrakter.version>3.0-SNAPSHOT</familie.kontrakter.version>
         <familie.eksterne-kontrakter.stonadsstatistikk-ef>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.stonadsstatistikk-ef>
         <familie.eksterne-kontrakter.saksstatistikk-ef>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.saksstatistikk-ef>
         <familie.eksterne-kontrakter.arbeidsoppfolging>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.arbeidsoppfolging>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <kotlin.version>1.8.21</kotlin.version>
         <springdoc.version>2.1.0</springdoc.version>
         <felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
-        <familie.kontrakter.version>3.0-SNAPSHOT</familie.kontrakter.version>
+        <familie.kontrakter.version>3.0_20230526091004_4787da7</familie.kontrakter.version>
         <familie.eksterne-kontrakter.stonadsstatistikk-ef>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.stonadsstatistikk-ef>
         <familie.eksterne-kontrakter.saksstatistikk-ef>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.saksstatistikk-ef>
         <familie.eksterne-kontrakter.arbeidsoppfolging>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.arbeidsoppfolging>

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/BrevController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/BrevController.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.iverksett.brev
 
 import no.nav.familie.ef.iverksett.brev.frittstående.FrittståendeBrevService
 import no.nav.familie.kontrakter.ef.felles.FrittståendeBrevDto
+import no.nav.familie.kontrakter.ef.felles.KarakterutskriftBrevDto
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -25,6 +26,14 @@ class BrevController(
         } else {
             frittståendeBrevService.opprettTask(data)
         }
+        return ResponseEntity.ok().build()
+    }
+
+    @PostMapping("/frittstaende/innhenting-karakterutskrift")
+    fun journalførBrevForInnhentingAvKarakterutskrift(
+        @RequestBody data: KarakterutskriftBrevDto,
+    ): ResponseEntity<Any> {
+        frittståendeBrevService.opprettTask(data)
         return ResponseEntity.ok().build()
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/domain/KarakterutskriftBrev.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/domain/KarakterutskriftBrev.kt
@@ -1,0 +1,28 @@
+package no.nav.familie.ef.iverksett.brev.domain
+
+import no.nav.familie.kontrakter.ef.felles.FrittståendeBrevType
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.time.LocalDateTime
+import java.time.Year
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+@Table("karakterutskrift_brev")
+data class KarakterutskriftBrev(
+    @Id
+    val id: UUID = UUID.randomUUID(),
+    val personIdent: String,
+    val oppgaveId: Long,
+    val eksternFagsakId: Long,
+    @Column("journalforende_enhet")
+    val journalførendeEnhet: String,
+    val fil: ByteArray,
+    val brevtype: FrittståendeBrevType,
+    @Column("ar")
+    val år: Year,
+    val journalpostResultat: JournalpostResultatMap = JournalpostResultatMap(),
+    val distribuerBrevResultat: DistribuerBrevResultatMap = DistribuerBrevResultatMap(),
+    val opprettetTid: LocalDateTime = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS),
+)

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/domain/KarakterutskriftBrev.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/domain/KarakterutskriftBrev.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.iverksett.brev.domain
 
 import no.nav.familie.kontrakter.ef.felles.FrittståendeBrevType
+import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.relational.core.mapping.Table
@@ -20,9 +21,10 @@ data class KarakterutskriftBrev(
     val journalførendeEnhet: String,
     val fil: ByteArray,
     val brevtype: FrittståendeBrevType,
-    @Column("ar")
-    val år: Year,
-    val journalpostResultat: JournalpostResultatMap = JournalpostResultatMap(),
-    val distribuerBrevResultat: DistribuerBrevResultatMap = DistribuerBrevResultatMap(),
+    @Column("gjeldende_ar")
+    val gjeldendeÅr: Year,
+    @Column("stonad_type")
+    val stønadType: StønadType,
+    val journalpostId: String? = null,
     val opprettetTid: LocalDateTime = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS),
 )

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/DistribuerFrittståendeBrevTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/DistribuerFrittståendeBrevTask.kt
@@ -40,7 +40,6 @@ class DistribuerFrittståendeBrevTask(
 ) : AsyncTaskStep {
 
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
     private sealed class Resultat
     private object OK : Resultat()

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/DistribuerKarakterutskriftBrevTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/DistribuerKarakterutskriftBrevTask.kt
@@ -1,0 +1,107 @@
+package no.nav.familie.ef.iverksett.brev.frittstående
+
+import no.nav.familie.ef.iverksett.brev.JournalpostClient
+import no.nav.familie.ef.iverksett.repository.findByIdOrThrow
+import no.nav.familie.http.client.RessursException
+import no.nav.familie.kontrakter.felles.dokdist.Distribusjonstype
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Loggtype
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.error.RekjørSenereException
+import no.nav.familie.prosessering.error.TaskExceptionUtenStackTrace
+import no.nav.familie.prosessering.internal.TaskService
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.web.client.HttpClientErrorException
+import java.lang.IllegalStateException
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = DistribuerKarakterutskriftBrevTask.TYPE,
+    maxAntallFeil = 50,
+    settTilManuellOppfølgning = true,
+    triggerTidVedFeilISekunder = 15 * 60L,
+    beskrivelse = "Distribuerer frittstående brev for innhenting av karakterutskrift.",
+)
+class DistribuerKarakterutskriftBrevTask(
+    private val karakterutskriftBrevRepository: KarakterutskriftBrevRepository,
+    private val journalpostClient: JournalpostClient,
+    private val taskService: TaskService,
+) : AsyncTaskStep {
+
+    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+    private sealed class Resultat
+    private object OK : Resultat()
+    private data class Dødsbo(val melding: String) : Resultat()
+
+    override fun doTask(task: Task) {
+        val brevId = UUID.fromString(task.payload)
+
+        val resultat: Resultat = distribuerKarakterutskriftBrev(brevId)
+
+        if (resultat is Dødsbo) {
+            håndterDødsbo(task, resultat)
+        }
+    }
+
+    private fun distribuerKarakterutskriftBrev(brevId: UUID): Resultat {
+        val brev = karakterutskriftBrevRepository.findByIdOrThrow(brevId)
+        val journalpostId = brev.journalpostId ?: throw IllegalStateException(
+            "Distribuering av frittstående brev for innhenting av karakterutskrift"
+                    + "med id=$brevId feilet. Fant ingen journalpostId på brevet."
+        )
+
+        try {
+            distribuerBrev(journalpostId)
+        } catch (e: RessursException) {
+            val cause = e.cause
+            when (cause) {
+                is HttpClientErrorException.Gone ->
+                    return Dødsbo("Dødsbo personIdent=${brev.personIdent} ${cause.responseBodyAsString}")
+
+                else -> throw e
+            }
+        }
+        return OK
+    }
+
+    private fun distribuerBrev(
+        journalpostId: String,
+    ): String {
+        val bestillingId = journalpostClient.distribuerBrev(journalpostId, Distribusjonstype.VIKTIG)
+        loggDistribuertBrev(journalpostId, bestillingId)
+        return bestillingId
+    }
+
+    private fun håndterDødsbo(task: Task, dødsbo: Dødsbo) {
+        val antallRekjørSenerePgaDødsbo = taskService.findTaskLoggByTaskId(task.id)
+            .count { it.type == Loggtype.KLAR_TIL_PLUKK && it.melding?.startsWith("Dødsbo") == true }
+        if (antallRekjørSenerePgaDødsbo < 7) {
+            logger.warn("Mottaker for vedtaksbrev behandling=${task.payload} har dødsbo, prøver å sende brev på nytt om 7 dager")
+            throw RekjørSenereException(dødsbo.melding, LocalDateTime.now().plusDays(7))
+        } else {
+            throw TaskExceptionUtenStackTrace("Er dødsbo og har feilet flere ganger: ${dødsbo.melding}")
+        }
+    }
+
+    private fun loggDistribuertBrev(journalpostId: String, bestillingId: String) {
+        logger.info(
+            "Distribuerer frittstående brev for innhenting av karakterutskrift med " +
+                    "journalpostId=$journalpostId og bestillingId=$bestillingId",
+        )
+    }
+
+    override fun onCompletion(task: Task) {
+        taskService.save(Task(DistribuerKarakterutskriftBrevTask.TYPE, task.payload, task.metadata))
+    }
+
+    companion object {
+
+        const val TYPE = "distribuerKarakterutskriftBrev"
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/FrittståendeBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/FrittståendeBrevService.kt
@@ -94,8 +94,9 @@ class FrittståendeBrevService(
                 journalførendeEnhet = data.journalførendeEnhet,
                 fil = data.fil,
                 brevtype = data.brevtype,
-                år = data.år,
+                gjeldendeÅr = data.gjeldendeÅr,
                 oppgaveId = data.oppgaveId,
+                stønadType = data.stønadType,
             )
         )
         taskService.save(Task(JournalførKarakterutskriftBrevTask.TYPE, brev.id.toString()))
@@ -111,7 +112,7 @@ class FrittståendeBrevService(
         if (karakterutskriftBrevRepository.existsByEksternFagsakIdAndOppgaveIdAndÅr(
                 data.eksternFagsakId,
                 data.oppgaveId,
-                data.år
+                data.gjeldendeÅr
             )
         ) {
             throw IllegalStateException("Skal ikke kunne opprette flere innhentingsbrev for fagsak med eksternId=${data.eksternFagsakId}")

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/JournalførKarakterutskriftBrevTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/JournalførKarakterutskriftBrevTask.kt
@@ -1,0 +1,63 @@
+package no.nav.familie.ef.iverksett.brev.frittstående
+
+import no.nav.familie.ef.iverksett.brev.JournalpostClient
+import no.nav.familie.ef.iverksett.repository.findByIdOrThrow
+import no.nav.familie.kontrakter.felles.dokarkiv.Dokumenttype
+import no.nav.familie.kontrakter.felles.dokarkiv.v2.ArkiverDokumentRequest
+import no.nav.familie.kontrakter.felles.dokarkiv.v2.Dokument
+import no.nav.familie.kontrakter.felles.dokarkiv.v2.Filtype
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.internal.TaskService
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = JournalførFrittståendeBrevTask.TYPE,
+    maxAntallFeil = 5,
+    triggerTidVedFeilISekunder = 15,
+    beskrivelse = "Journalfører brev for innhenting av karakterutskrift.",
+)
+class JournalførKarakterutskriftBrevTask(
+    private val journalpostClient: JournalpostClient,
+    private val taskService: TaskService,
+    private val karakterutskriftBrevRepository: KarakterutskriftBrevRepository,
+) : AsyncTaskStep {
+
+    override fun doTask(task: Task) {
+        val callId = task.callId
+        val brevId = UUID.fromString(task.payload)
+        val brev = karakterutskriftBrevRepository.findByIdOrThrow(brevId)
+
+        // TODO: Ikke hardkod dokumenttype
+        journalpostClient.arkiverDokument(
+            ArkiverDokumentRequest(
+                fnr = brev.personIdent,
+                forsøkFerdigstill = true,
+                hoveddokumentvarianter = listOf(
+                    Dokument(
+                        dokument = brev.fil,
+                        filtype = Filtype.PDFA,
+                        dokumenttype = Dokumenttype.OVERGANGSSTØNAD_FRITTSTÅENDE_BREV,
+                        tittel = brev.brevtype.tittel,
+                    ),
+                ),
+                fagsakId = brev.eksternFagsakId.toString(),
+                journalførendeEnhet = brev.journalførendeEnhet,
+                eksternReferanseId = callId
+            ),
+            saksbehandler = null
+        ).journalpostId
+    }
+
+    override fun onCompletion(task: Task) {
+        // TODO: Distribuer brev
+    }
+
+    companion object {
+
+        const val TYPE = "journalførKarakterutskriftBrev"
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/KarakterutskriftBrevRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/KarakterutskriftBrevRepository.kt
@@ -1,15 +1,9 @@
 package no.nav.familie.ef.iverksett.brev.frittstående
 
-import no.nav.familie.ef.iverksett.brev.domain.DistribuerBrevResultatMap
-import no.nav.familie.ef.iverksett.brev.domain.JournalpostResultatMap
 import no.nav.familie.ef.iverksett.brev.domain.KarakterutskriftBrev
 import no.nav.familie.ef.iverksett.repository.InsertUpdateRepository
 import no.nav.familie.ef.iverksett.repository.RepositoryInterface
-import org.springframework.data.jdbc.repository.query.Modifying
-import org.springframework.data.jdbc.repository.query.Query
 import org.springframework.stereotype.Repository
-import org.springframework.transaction.annotation.Propagation
-import org.springframework.transaction.annotation.Transactional
 import java.time.Year
 import java.util.UUID
 
@@ -18,14 +12,4 @@ interface KarakterutskriftBrevRepository :
     RepositoryInterface<KarakterutskriftBrev, UUID>, InsertUpdateRepository<KarakterutskriftBrev> {
 
     fun existsByEksternFagsakIdAndOppgaveIdAndÅr(eksternFagsakId: Long, oppgaveId: Long, år: Year): Boolean
-
-    @Modifying
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    @Query("UPDATE karakterutskrift_brev SET journalpost_resultat=:journalpostresultat WHERE id=:id")
-    fun oppdaterJournalpostResultat(id: UUID, journalpostresultat: JournalpostResultatMap)
-
-    @Modifying
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    @Query("UPDATE karakterutskrift_brev SET distribuer_brev_resultat=:distribuerBrevResultat WHERE id=:id")
-    fun oppdaterDistribuerBrevResultat(id: UUID, distribuerBrevResultat: DistribuerBrevResultatMap)
 }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/KarakterutskriftBrevRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/KarakterutskriftBrevRepository.kt
@@ -1,0 +1,31 @@
+package no.nav.familie.ef.iverksett.brev.frittstående
+
+import no.nav.familie.ef.iverksett.brev.domain.DistribuerBrevResultatMap
+import no.nav.familie.ef.iverksett.brev.domain.JournalpostResultatMap
+import no.nav.familie.ef.iverksett.brev.domain.KarakterutskriftBrev
+import no.nav.familie.ef.iverksett.repository.InsertUpdateRepository
+import no.nav.familie.ef.iverksett.repository.RepositoryInterface
+import org.springframework.data.jdbc.repository.query.Modifying
+import org.springframework.data.jdbc.repository.query.Query
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import java.time.Year
+import java.util.UUID
+
+@Repository
+interface KarakterutskriftBrevRepository :
+    RepositoryInterface<KarakterutskriftBrev, UUID>, InsertUpdateRepository<KarakterutskriftBrev> {
+
+    fun existsByEksternFagsakIdAndOppgaveIdAndÅr(eksternFagsakId: Long, oppgaveId: Long, år: Year): Boolean
+
+    @Modifying
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Query("UPDATE karakterutskrift_brev SET journalpost_resultat=:journalpostresultat WHERE id=:id")
+    fun oppdaterJournalpostResultat(id: UUID, journalpostresultat: JournalpostResultatMap)
+
+    @Modifying
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Query("UPDATE karakterutskrift_brev SET distribuer_brev_resultat=:distribuerBrevResultat WHERE id=:id")
+    fun oppdaterDistribuerBrevResultat(id: UUID, distribuerBrevResultat: DistribuerBrevResultatMap)
+}

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/OppdaterOppgaveForInnhentingAvKarakterutskriftTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/OppdaterOppgaveForInnhentingAvKarakterutskriftTask.kt
@@ -1,0 +1,31 @@
+package no.nav.familie.ef.iverksett.brev.frittstående
+
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.internal.TaskService
+import org.springframework.stereotype.Service
+
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = DistribuerKarakterutskriftBrevTask.TYPE,
+    maxAntallFeil = 50,
+    settTilManuellOppfølgning = true,
+    triggerTidVedFeilISekunder = 15 * 60L,
+    beskrivelse = "Oppdaterer beskrivelse på oppgave for innhenting av karakterutskrift.",
+)
+class OppdaterOppgaveForInnhentingAvKarakterutskriftTask(
+    private val taskService: TaskService,
+) : AsyncTaskStep {
+
+
+    override fun doTask(task: Task) {
+        //TODO: Implementer
+    }
+
+    companion object {
+
+        const val TYPE = "oppdaterOppgaveForInnhentingAvKarakterutskrift"
+    }
+}


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-8258)

Fortsettelse på:
* https://github.com/navikt/familie-ef-sak/pull/2246
* https://github.com/navikt/familie-ef-sak/pull/2245
* https://github.com/navikt/familie-ef-sak/pull/2241

Denne PRen legger til støtte for å motta brev fra ef-sak. Dette brevet skal så lagres ned i iverksett og det skal opprettes en task for journalføring av brevet. Når denne tasken lykkes skal det opprettes en ny task for distribuering av brevet.

Dette kommer til å testes i preprod. Jeg og Eirik har blitt enige om å skrive enhetstester senere.