### PR TITLE
Skal sende ut brev til andre brevmottakere selv om distribuering feiler for annen mottaker

### DIFF
--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brev/DistribuerVedtaksbrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brev/DistribuerVedtaksbrevTaskTest.kt
@@ -120,7 +120,7 @@ internal class DistribuerVedtaksbrevTaskTest {
             "1" to journalpostResultater[0],
             "2" to journalpostResultater[1],
         )
-        every { iverksettResultatService.hentdistribuerVedtaksbrevResultat(behandlingId) } returns null
+        every { iverksettResultatService.hentdistribuerVedtaksbrevResultat(behandlingId) } returns null andThen mapOf(journalpostResultater[0].journalpostId to DistribuerBrevResultat(bestillingIder[0]))
         every { journalpostClient.distribuerBrev(any(), any()) } returns bestillingIder[0] andThen bestillingIder[1]
         every {
             iverksettResultatService.oppdaterDistribuerVedtaksbrevResultat(


### PR DESCRIPTION
https://nav-it.slack.com/archives/C01087QRJ2U/p1685537308509849
**Hvorfor?**
Vi har en feilet `DistribuerVedtaksbrevTask` der bruker ikke har adresse, men saksbehandler har valgt at brev også skal gå til verge. Fordi dokdist feiler ved distribusjon til bruker forsøker vi aldri å distribuere til verge. Med denne endringen vil vi la tasken gå gjennom, og ikke feile dersom den klarer å distribuere brevet til minst en av brevmottakerne.

Litt usikker på om vi egentlig vil gjøre dette, så tar gjerne innspill til andre måter vi kan håndtere den feilede tasken. Tenker også å lage noen tester dersom vi går for denne løsningen.

