### PR TITLE
Skal ikke kunne opprette to innslag i karakterutskrift_brev med samme…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/BrevController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/BrevController.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.iverksett.brev
 import no.nav.familie.ef.iverksett.brev.frittstående.FrittståendeBrevService
 import no.nav.familie.kontrakter.ef.felles.FrittståendeBrevDto
 import no.nav.familie.kontrakter.ef.felles.KarakterutskriftBrevDto
+import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -32,8 +33,8 @@ class BrevController(
     @PostMapping("/frittstaende/innhenting-karakterutskrift")
     fun journalførBrevForInnhentingAvKarakterutskrift(
         @RequestBody data: KarakterutskriftBrevDto,
-    ): ResponseEntity<Any> {
+    ): Ressurs<Unit> {
         frittståendeBrevService.opprettTask(data)
-        return ResponseEntity.ok().build()
+        return Ressurs.success(Unit)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/FrittståendeBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/FrittståendeBrevService.kt
@@ -97,7 +97,7 @@ class FrittståendeBrevService(
             brevDto.brevtype != FrittståendeBrevType.INNHENTING_AV_KARAKTERUTSKRIFT_HOVEDPERIODE &&
             brevDto.brevtype != FrittståendeBrevType.INNHENTING_AV_KARAKTERUTSKRIFT_UTVIDET_PERIODE
         ) {
-            throw IllegalArgumentException("Skal ikke opprette automatiske innhentingsbrev for frittstående brev av type ${brevDto.brevtype}")
+            throw ApiFeil("Skal ikke opprette automatiske innhentingsbrev for frittstående brev av type ${brevDto.brevtype}", HttpStatus.BAD_REQUEST)
         }
         if (karakterutskriftBrevRepository.existsByEksternFagsakIdAndOppgaveIdAndGjeldendeÅr(
                 brevDto.eksternFagsakId,
@@ -105,7 +105,7 @@ class FrittståendeBrevService(
                 brevDto.gjeldendeÅr,
             )
         ) {
-            throw IllegalStateException("Skal ikke kunne opprette flere innhentingsbrev for fagsak med eksternId=${brevDto.eksternFagsakId}")
+            throw ApiFeil("Skal ikke kunne opprette flere innhentingsbrev for fagsak med eksternId=${brevDto.eksternFagsakId}", HttpStatus.BAD_REQUEST)
         }
         if (karakterutskriftBrevRepository.existsByEksternFagsakIdAndGjeldendeÅrAndBrevtype(
                 brevDto.eksternFagsakId,
@@ -113,7 +113,7 @@ class FrittståendeBrevService(
                 brevDto.brevtype,
             )
         ) {
-            throw IllegalStateException("Skal ikke kunne opprette flere identiske brev til mottaker. Fagsak med eksternId=${brevDto.eksternFagsakId}")
+            throw ApiFeil("Skal ikke kunne opprette flere identiske brev til mottaker. Fagsak med eksternId=${brevDto.eksternFagsakId}", HttpStatus.BAD_REQUEST)
         }
     }
 }

--- a/src/main/resources/db/migration/V19__karakterutskrift_brev_unik_fagsak.sql
+++ b/src/main/resources/db/migration/V19__karakterutskrift_brev_unik_fagsak.sql
@@ -1,0 +1,1 @@
+ALTER TABLE karakterutskrift_brev ADD CONSTRAINT fagsakIdBrevtypeGjeldendeAar UNIQUE (ekstern_fagsak_id, brevtype, gjeldende_ar);

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/ServerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/ServerTest.kt
@@ -60,6 +60,7 @@ abstract class ServerTest {
         )
         namedParameterJdbcTemplate.update("TRUNCATE TABLE task, task_logg CASCADE", MapSqlParameterSource())
         namedParameterJdbcTemplate.update("TRUNCATE TABLE frittstaende_brev", MapSqlParameterSource())
+        namedParameterJdbcTemplate.update("TRUNCATE TABLE karakterutskrift_brev", MapSqlParameterSource())
     }
 
     protected fun getPort(): String {

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brev/FrittståendeBrevControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brev/FrittståendeBrevControllerTest.kt
@@ -1,0 +1,46 @@
+package no.nav.familie.ef.iverksett.brev
+
+import no.nav.familie.ef.iverksett.ServerTest
+import no.nav.familie.ef.iverksett.brev.frittstående.KarakterInnhentingBrevUtil.brevDto
+import no.nav.familie.kontrakter.felles.Ressurs
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.web.client.exchange
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+
+class FrittståendeBrevControllerTest : ServerTest() {
+
+    @BeforeEach
+    fun setUp() {
+        headers.setBearerAuth(lokalTestToken)
+        headers.set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+    }
+
+    @Test
+    fun `Skal ikke kunne opprette to task for samme fagsak-brev-skoleår`() {
+        val eksternFagsakId = 123L
+
+        val brevDto1 = brevDto(eksternFagsakId, 1L)
+        val brevDto2 = brevDto(eksternFagsakId, 2L)
+
+        val respons: ResponseEntity<Ressurs<Unit>> = restTemplate.exchange(
+            localhostUrl("/api/brev/frittstaende/innhenting-karakterutskrift"),
+            HttpMethod.POST,
+            HttpEntity(brevDto1, headers),
+        )
+
+        val respons2: ResponseEntity<Ressurs<Unit>> = restTemplate.exchange(
+            localhostUrl("/api/brev/frittstaende/innhenting-karakterutskrift"),
+            HttpMethod.POST,
+            HttpEntity(brevDto2, headers),
+        )
+        assertThat(respons.statusCode.value()).isEqualTo(200)
+        assertThat(respons2.statusCode.value()).isEqualTo(400)
+        assertThat(respons2.body?.melding).contains("Skal ikke kunne opprette flere identiske brev til mottaker. Fagsak med eksternId=")
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brev/FrittståendeBrevServiceIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brev/FrittståendeBrevServiceIntegrasjonsTest.kt
@@ -1,0 +1,30 @@
+package no.nav.familie.ef.iverksett.brev
+
+import no.nav.familie.ef.iverksett.ServerTest
+import no.nav.familie.ef.iverksett.brev.frittstående.FrittståendeBrevService
+import no.nav.familie.ef.iverksett.brev.frittstående.KarakterInnhentingBrevUtil.brevDto
+import no.nav.familie.ef.iverksett.infrastruktur.advice.ApiFeil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+
+class FrittståendeBrevServiceIntegrasjonsTest : ServerTest() {
+
+    @Autowired
+    lateinit var frittståendeBrevService: FrittståendeBrevService
+
+    @Test
+    fun `Skal ikke kunne opprette to task for samme fagsak-brev-skoleår `() {
+        val eksternFagsakId = 123L
+
+        val brevDto1 = brevDto(eksternFagsakId, 1L)
+        val brevDto2 = brevDto(eksternFagsakId, 2L)
+
+        frittståendeBrevService.opprettTask(brevDto1)
+        val feil = assertThrows<ApiFeil> {
+            frittståendeBrevService.opprettTask(brevDto2)
+        }
+        assertThat(feil.feil).contains("Skal ikke kunne opprette flere identiske brev til mottaker. Fagsak med eksternId=$eksternFagsakId")
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/FrittståendeBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/FrittståendeBrevServiceTest.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ef.iverksett.brev.JournalpostClient
 import no.nav.familie.ef.iverksett.brev.domain.KarakterutskriftBrev
 import no.nav.familie.ef.iverksett.brev.domain.tilDto
 import no.nav.familie.ef.iverksett.brev.frittstående.KarakterInnhentingBrevUtil.opprettBrev
+import no.nav.familie.ef.iverksett.infrastruktur.advice.ApiFeil
 import no.nav.familie.kontrakter.ef.felles.FrittståendeBrevType
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
@@ -15,8 +16,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.lang.IllegalArgumentException
-import java.lang.IllegalStateException
 
 internal class FrittståendeBrevServiceTest {
 
@@ -60,11 +59,11 @@ internal class FrittståendeBrevServiceTest {
 
             every { karakterutskriftBrevRepository.existsByEksternFagsakIdAndOppgaveIdAndGjeldendeÅr(any(), any(), any()) } returns false
 
-            val feil = assertThrows<IllegalArgumentException> { frittståendeBrevService.opprettTask(brevDto) }
+            val feil = assertThrows<ApiFeil> { frittståendeBrevService.opprettTask(brevDto) }
 
             verify(exactly = 0) { karakterutskriftBrevRepository.insert(any()) }
             verify(exactly = 0) { taskService.save(any()) }
-            assertThat(feil.message).isEqualTo("Skal ikke opprette automatiske innhentingsbrev for frittstående brev av type ${brevDto.brevtype}")
+            assertThat(feil.feil).isEqualTo("Skal ikke opprette automatiske innhentingsbrev for frittstående brev av type ${brevDto.brevtype}")
         }
 
         @Test
@@ -74,11 +73,11 @@ internal class FrittståendeBrevServiceTest {
 
             every { karakterutskriftBrevRepository.existsByEksternFagsakIdAndOppgaveIdAndGjeldendeÅr(any(), any(), any()) } returns true
 
-            val feil = assertThrows<IllegalStateException> { frittståendeBrevService.opprettTask(brevDto) }
+            val feil = assertThrows<ApiFeil> { frittståendeBrevService.opprettTask(brevDto) }
 
             verify(exactly = 0) { karakterutskriftBrevRepository.insert(any()) }
             verify(exactly = 0) { taskService.save(any()) }
-            assertThat(feil.message).isEqualTo("Skal ikke kunne opprette flere innhentingsbrev for fagsak med eksternId=${brevDto.eksternFagsakId}")
+            assertThat(feil.feil).isEqualTo("Skal ikke kunne opprette flere innhentingsbrev for fagsak med eksternId=${brevDto.eksternFagsakId}")
         }
 
         @Test
@@ -89,11 +88,11 @@ internal class FrittståendeBrevServiceTest {
             every { karakterutskriftBrevRepository.existsByEksternFagsakIdAndOppgaveIdAndGjeldendeÅr(any(), any(), any()) } returns false
             every { karakterutskriftBrevRepository.existsByEksternFagsakIdAndGjeldendeÅrAndBrevtype(any(), any(), any()) } returns true
 
-            val feil = assertThrows<IllegalStateException> { frittståendeBrevService.opprettTask(brevDto) }
+            val feil = assertThrows<ApiFeil> { frittståendeBrevService.opprettTask(brevDto) }
 
             verify(exactly = 0) { karakterutskriftBrevRepository.insert(any()) }
             verify(exactly = 0) { taskService.save(any()) }
-            assertThat(feil.message).isEqualTo("Skal ikke kunne opprette flere identiske brev til mottaker. Fagsak med eksternId=${brevDto.eksternFagsakId}")
+            assertThat(feil.feil).isEqualTo("Skal ikke kunne opprette flere identiske brev til mottaker. Fagsak med eksternId=${brevDto.eksternFagsakId}")
         }
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/KarakterInnhentingBrevUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/KarakterInnhentingBrevUtil.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.iverksett.brev.frittstående
 
 import no.nav.familie.ef.iverksett.brev.domain.KarakterutskriftBrev
 import no.nav.familie.kontrakter.ef.felles.FrittståendeBrevType
+import no.nav.familie.kontrakter.ef.felles.KarakterutskriftBrevDto
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import java.time.Year
 import java.util.UUID
@@ -19,5 +20,16 @@ object KarakterInnhentingBrevUtil {
         gjeldendeÅr = Year.of(2023),
         stønadType = StønadType.OVERGANGSSTØNAD,
         journalpostId = journalpostId,
+    )
+
+    fun brevDto(eksternFagsakId: Long, oppgaveId: Long) = KarakterutskriftBrevDto(
+        "123".toByteArray(),
+        oppgaveId,
+        "ident",
+        eksternFagsakId,
+        "4489",
+        FrittståendeBrevType.INNHENTING_AV_KARAKTERUTSKRIFT_HOVEDPERIODE,
+        Year.of(2023),
+        StønadType.OVERGANGSSTØNAD,
     )
 }


### PR DESCRIPTION
… eksternFagsakId, brevtype og gjeldende år

Relatert til [utsending av karakterutskriftsbrev](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-8258)
 
**Hvorfor?**
I forbindelse med testing i dev klarte vi å opprette to karakterutskriftsbrevTasker for samme eksternFagsakId, brevtype og gjeldende år. Vi tror dette skjedde fordi to requester fra ef-sak gikk mot to forskjellige poder hos iverksett. Legger derfor til en unikshetsconstraint på db-nivå så det ikke skal være mulig å opprette duplikater i tabellen.