### PR TITLE
g-omregning: Melding til bruker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/Grunnbeløp.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/Grunnbeløp.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.iverksett.brukernotifikasjon
 
 import no.nav.familie.kontrakter.felles.Månedsperiode
 import java.math.BigDecimal
-import java.math.MathContext
 import java.math.RoundingMode
 import java.time.LocalDate
 import java.time.YearMonth
@@ -39,4 +38,3 @@ data class Grunnbeløp(
 )
 
 fun LocalDate.norskFormat() = this.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))
-

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
@@ -16,10 +16,7 @@ class BrukernotifikasjonKafkaProducerTest {
     private val kafkaTemplate = mockk<KafkaTemplate<NokkelInput, BeskjedInput>>()
     private val brukernotifikasjonKafkaProducer = BrukernotifikasjonKafkaProducer(kafkaTemplate)
 
-    private val forventetGOmregningTekst = """
-        Fra ${nyesteGrunnbeløp.periode.fomDato.norskFormat()} har folketrygdens grunnbeløp økt til ${nyesteGrunnbeløp.grunnbeløp} kroner og din forventede inntekt er oppjustert til 200000 kroner. Overgangsstønaden din er derfor endret.
-        Du må si ifra til oss hvis inntekten din øker eller reduseres med 10 prosent eller mer.
-    """.trimIndent()
+    private val forventetGOmregningTekst = G_OMREGNING_MELDING_TIL_BRUKER
 
     @Test
     fun `lagBeskjed genererer riktig melding`() {

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/GrunnbeløpTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/GrunnbeløpTest.kt
@@ -1,27 +1,7 @@
 package no.nav.familie.ef.iverksett.brukernotifikasjon
 
-import io.mockk.every
-import io.mockk.just
-import io.mockk.mockk
-import io.mockk.mockkObject
-import io.mockk.runs
-import io.mockk.unmockkObject
-import io.mockk.verify
-import no.nav.familie.ef.iverksett.infrastruktur.transformer.toDomain
-import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
-import no.nav.familie.ef.iverksett.lagIverksett
-import no.nav.familie.ef.iverksett.repository.findByIdOrThrow
-import no.nav.familie.ef.iverksett.util.mockFeatureToggleService
-import no.nav.familie.ef.iverksett.util.opprettIverksettDto
-import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
-import no.nav.familie.prosessering.domene.Task
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.math.BigDecimal
-import java.time.LocalDate
-import java.util.UUID
 
 class GrunnbeløpTest {
 


### PR DESCRIPTION
**Hvorfor:**
For å unngå feil melding (eller feil i innhold) til bruker vil vi sende en generell melding til alle (uten inntekt) ved g-omregning.