### PR TITLE
Skal sjekke person med relasjoner ved utledning av behandlende enhet for tilbakekreving 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/Grunnbeløp.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/Grunnbeløp.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.iverksett.brukernotifikasjon
 
 import no.nav.familie.kontrakter.felles.Månedsperiode
 import java.math.BigDecimal
-import java.math.MathContext
 import java.math.RoundingMode
 import java.time.LocalDate
 import java.time.YearMonth
@@ -39,4 +38,3 @@ data class Grunnbeløp(
 )
 
 fun LocalDate.norskFormat() = this.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))
-

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/felles/FamilieIntegrasjonerClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/felles/FamilieIntegrasjonerClient.kt
@@ -27,8 +27,6 @@ class FamilieIntegrasjonerClient(
     private val aktørUri =
         UriComponentsBuilder.fromUri(integrasjonUri).pathSegment(PATH_AKTØR).build().toUri()
 
-    private fun arbeidsfordelingUri(tema: String) =
-        UriComponentsBuilder.fromUri(integrasjonUri).pathSegment(PATH_ARBEIDSFORDELING, tema).build().toUri()
 
     private fun arbeidsfordelingOppfølingUri(tema: String) =
         UriComponentsBuilder.fromUri(integrasjonUri).pathSegment(PATH_ARBEIDSFORDELING_OPPFØLGING, tema).build().toUri()
@@ -54,11 +52,6 @@ class FamilieIntegrasjonerClient(
     fun hentBehandlendeEnhetForOppfølging(personident: String): Enhet? {
         val response =
             postForEntity<Ressurs<List<Enhet>>>(arbeidsfordelingOppfølingUri(TEMA_ENSLIG_FORSØRGER), Ident(personident))
-        return response.getDataOrThrow().firstOrNull()
-    }
-
-    fun hentBehandlendeEnhetForBehandling(personident: String): Enhet? {
-        val response = postForEntity<Ressurs<List<Enhet>>>(arbeidsfordelingUri(TEMA_ENSLIG_FORSØRGER), Ident(personident))
         return response.getDataOrThrow().firstOrNull()
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/OpprettTilbakekrevingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/OpprettTilbakekrevingTask.kt
@@ -116,8 +116,8 @@ class OpprettTilbakekrevingTask(
 
     private fun lagTilbakekrevingRequest(iverksett: IverksettData): OpprettTilbakekrevingRequest {
         // Henter ut på nytt, selv om noe finnes i iverksett-dto'en
-        val enhet = familieIntegrasjonerClient.hentBehandlendeEnhetForBehandling(iverksett.søker.personIdent)!!
-        return iverksett.tilOpprettTilbakekrevingRequest(enhet)
+        val enhet = familieIntegrasjonerClient.hentBehandlendeEnhetForBehandlingMedRelasjoner(iverksett.søker.personIdent).firstOrNull()
+        return iverksett.tilOpprettTilbakekrevingRequest(enhet ?: error("Kan ikke finne behandlende enhet for behandling=${iverksett.behandling.behandlingId}"))
     }
 
     private fun finnesÅpenTilbakekrevingsbehandling(nyIverksett: IverksettData): Boolean =

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/TilbakekrevingListener.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/TilbakekrevingListener.kt
@@ -60,7 +60,7 @@ class TilbakekrevingListener(
             logger.info("HentFagsystemsbehandlingRequest er mottatt i kafka med key=$key og data=$data")
             val iverksett = iverksettingRepository.findByEksternId(request.eksternId.toLong()).data
             sjekkFagsakIdKonsistens(iverksett, request)
-            familieIntegrasjonerClient.hentBehandlendeEnhetForBehandling(iverksett.søker.personIdent)?.let {
+            familieIntegrasjonerClient.hentBehandlendeEnhetForBehandlingMedRelasjoner(iverksett.søker.personIdent).firstOrNull()?.let {
                 val fagsystemsbehandling = iverksett.tilFagsystembehandling(it)
                 tilbakekrevingProducer.send(fagsystemsbehandling, key)
             } ?: error("Kan ikke finne behandlende enhet for søker på behandling ${iverksett.behandling.behandlingId}")

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/GrunnbeløpTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/GrunnbeløpTest.kt
@@ -1,27 +1,7 @@
 package no.nav.familie.ef.iverksett.brukernotifikasjon
 
-import io.mockk.every
-import io.mockk.just
-import io.mockk.mockk
-import io.mockk.mockkObject
-import io.mockk.runs
-import io.mockk.unmockkObject
-import io.mockk.verify
-import no.nav.familie.ef.iverksett.infrastruktur.transformer.toDomain
-import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
-import no.nav.familie.ef.iverksett.lagIverksett
-import no.nav.familie.ef.iverksett.repository.findByIdOrThrow
-import no.nav.familie.ef.iverksett.util.mockFeatureToggleService
-import no.nav.familie.ef.iverksett.util.opprettIverksettDto
-import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
-import no.nav.familie.prosessering.domene.Task
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.math.BigDecimal
-import java.time.LocalDate
-import java.util.UUID
 
 class GrunnbeløpTest {
 

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/OpprettTilbakekrevingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/OpprettTilbakekrevingTaskTest.kt
@@ -50,8 +50,8 @@ internal class OpprettTilbakekrevingTaskTest {
     @BeforeEach
     fun init() {
         every { tilbakekrevingClient.finnesÅpenBehandling(any()) } returns false
-        every { familieIntegrasjonerClient.hentBehandlendeEnhetForBehandling(any()) } returns
-            Enhet("1", "Oslo")
+        every { familieIntegrasjonerClient.hentBehandlendeEnhetForBehandlingMedRelasjoner(any()) } returns
+            listOf(Enhet("1", "Oslo"))
         every { tilbakekrevingClient.opprettBehandling(any()) } just Runs
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/TilbakekrevingListenerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/TilbakekrevingListenerTest.kt
@@ -37,8 +37,8 @@ internal class TilbakekrevingListenerTest {
     internal fun setUp() {
         every { iverksettingRepository.findByEksternId(any()) }
             .returns(lagIverksett(behandling))
-        every { familieIntegrasjonerClient.hentBehandlendeEnhetForBehandling(any()) }
-            .returns(Enhet(enhetId = "0", enhetNavn = "navn"))
+        every { familieIntegrasjonerClient.hentBehandlendeEnhetForBehandlingMedRelasjoner(any()) }
+            .returns(listOf(Enhet(enhetId = "0", enhetNavn = "navn")))
         every { tilbakekrevingProducer.send(any(), any()) } just runs
         listener = TilbakekrevingListener(iverksettingRepository, familieIntegrasjonerClient, tilbakekrevingProducer)
     }


### PR DESCRIPTION
**Hvorfor?**
Når vi oppretter tilbakekrevingsbehandlinger sender vi med behandlende enhet. Denne bruker bl.a. til å sette `BehandleSak`- og `GodkjenneVedtak`-oppgavene på riktig enhet. Så langt har vi bare sjekket gjeldene enhet for brukeren, men vi må også sjekke for brukers relasjoner for å få riktig enhet for behandlingen.

Vi har hatt [minst en sak i prod](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12500) der bruker ikke har vært skjermet, men hatt en relasjon til til en nav ansatt. Da skal behandlingen gjøres av 4483, ikke 4489, men fordi vi bare sjekket på bruker ved oversendelse til tilbakekreving ble behandlingen satt på 4489.