### PR TITLE
Skal bruke tittel istedenfor brevtype ved journalføring av frittstående brev

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <kotlin.version>1.8.21</kotlin.version>
         <springdoc.version>2.1.0</springdoc.version>
         <felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
-        <familie.kontrakter.version>3.0_20230606140124_22e9aad</familie.kontrakter.version>
+        <familie.kontrakter.version>3.0_20230615142948_f6dc470</familie.kontrakter.version>
         <familie.eksterne-kontrakter.stonadsstatistikk-ef>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.stonadsstatistikk-ef>
         <familie.eksterne-kontrakter.saksstatistikk-ef>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.saksstatistikk-ef>
         <familie.eksterne-kontrakter.arbeidsoppfolging>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.arbeidsoppfolging>

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/domain/FrittståendeBrev.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/domain/FrittståendeBrev.kt
@@ -22,7 +22,9 @@ data class FrittståendeBrev(
     val stønadstype: StønadType,
     val mottakere: Brevmottakere,
     val fil: ByteArray,
-    val brevtype: FrittståendeBrevType,
+    @Deprecated("Skal erstattes av tittel")
+    val brevtype: FrittståendeBrevType? = null,
+    val tittel: String? = null,
     val journalpostResultat: JournalpostResultatMap = JournalpostResultatMap(),
     val distribuerBrevResultat: DistribuerBrevResultatMap = DistribuerBrevResultatMap(),
     val opprettetTid: LocalDateTime = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS),

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/FrittståendeBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/FrittståendeBrevService.kt
@@ -42,7 +42,7 @@ class FrittståendeBrevService(
                         data.fil,
                         Filtype.PDFA,
                         dokumenttype = stønadstypeTilDokumenttype(data.stønadType),
-                        tittel = data.brevtype.tittel,
+                        tittel = data.tittel,
                     ),
                 ),
                 fagsakId = data.eksternFagsakId.toString(),
@@ -78,6 +78,7 @@ class FrittståendeBrevService(
                 mottakere = Brevmottakere(mottakere.map { it.toDomain() }),
                 fil = data.fil,
                 brevtype = data.brevtype,
+                tittel = data.tittel,
             ),
         )
         taskService.save(Task(JournalførFrittståendeBrevTask.TYPE, brev.id.toString()))

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/JournalførFrittståendeBrevTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/JournalførFrittståendeBrevTask.kt
@@ -77,7 +77,7 @@ class JournalførFrittståendeBrevTask(
                 frittståendeBrev.fil,
                 Filtype.PDFA,
                 dokumenttype = stønadstypeTilDokumenttype(frittståendeBrev.stønadstype),
-                tittel = frittståendeBrev.brevtype.tittel,
+                tittel = utledBrevtittel(frittståendeBrev),
             ),
         ),
         fagsakId = frittståendeBrev.eksternFagsakId.toString(),
@@ -85,6 +85,10 @@ class JournalførFrittståendeBrevTask(
         eksternReferanseId = "$callId-$index",
         avsenderMottaker = avsenderMottaker(frittståendeBrev, brevmottaker),
     )
+
+    private fun utledBrevtittel(frittståendeBrev: FrittståendeBrev): String =
+        frittståendeBrev.tittel ?: frittståendeBrev.brevtype?.tittel
+            ?: throw IllegalStateException("Frittstående brev mangler både tittel og brevtype")
 
     private fun avsenderMottaker(
         frittståendeBrev: FrittståendeBrev,

--- a/src/main/resources/db/migration/V20__frittstående_brev_tittel.sql
+++ b/src/main/resources/db/migration/V20__frittstående_brev_tittel.sql
@@ -1,0 +1,2 @@
+ALTER TABLE frittstaende_brev
+    ADD COLUMN tittel VARCHAR;

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/FrittståendeBrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/FrittståendeBrevRepositoryTest.kt
@@ -32,6 +32,7 @@ internal class FrittståendeBrevRepositoryTest : ServerTest() {
         assertThat(oppdatertBrev.mottakere).isEqualTo(brev.mottakere)
         assertThat(oppdatertBrev.fil).isEqualTo(brev.fil)
         assertThat(oppdatertBrev.brevtype).isEqualTo(brev.brevtype)
+        assertThat(oppdatertBrev.tittel).isEqualTo(brev.tittel)
         assertThat(oppdatertBrev.journalpostResultat).isEqualTo(brev.journalpostResultat)
         assertThat(oppdatertBrev.distribuerBrevResultat).isEqualTo(brev.distribuerBrevResultat)
         assertThat(oppdatertBrev.opprettetTid).isEqualTo(brev.opprettetTid)

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/FrittståendeBrevUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/FrittståendeBrevUtil.kt
@@ -32,5 +32,6 @@ object FrittståendeBrevUtil {
         ),
         fil = byteArrayOf(13),
         brevtype = FrittståendeBrevType.INFORMASJONSBREV,
+        tittel = "tittel123",
     )
 }

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/JournalførFrittståendeBrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brev/frittstående/JournalførFrittståendeBrevTaskTest.kt
@@ -17,6 +17,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.data.repository.findByIdOrNull
 import java.util.UUID
 
@@ -125,5 +126,19 @@ internal class JournalførFrittståendeBrevTaskTest {
 
         assertThat(arkivrequests[1].fnr).isEqualTo("11")
         assertThat(arkivrequests[1].avsenderMottaker?.id).isEqualTo("22")
+    }
+
+    @Test
+    internal fun `skal feile dersom tittel og brevtype begge er null`() {
+        every { frittståendeBrevRepository.findByIdOrNull(any()) } returns opprettFrittståendeBrev().copy(
+            tittel = null,
+            brevtype = null,
+        )
+
+        val feil = assertThrows<IllegalStateException> {
+            service.doTask(Task(JournalførFrittståendeBrevTask.TYPE, UUID.randomUUID().toString()))
+        }
+
+        assertThat(feil.message).contains("Frittstående brev mangler både tittel og brevtype")
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/util/IverksettMockUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/util/IverksettMockUtil.kt
@@ -368,6 +368,7 @@ fun opprettFrittståendeBrevDto(): FrittståendeBrevDto {
         journalførendeEnhet = "4489",
         saksbehandlerIdent = "saksbehandlerIdent",
         stønadType = StønadType.OVERGANGSSTØNAD,
+        tittel = "brevtittel",
     )
 }
 


### PR DESCRIPTION
**Hvorfor?**
Fortsettelse på https://github.com/navikt/familie-ef-sak/pull/2280

[Ved overgangen til frittstående sanitybrev](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12119) øsnker vi å kunne sende med brevtittel fra sanity, istedenfor å mappe om til en enum/brevtype. Dette gjør at Mirja kan kontrollere hva brevene skal hete i dokumentoversikten.