### PR TITLE
Skal ikke sende statistikk på utgifter skolepenger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
         <kotlin.version>1.8.22</kotlin.version>
         <springdoc.version>2.1.0</springdoc.version>
         <felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
-        <familie.kontrakter.version>3.0_20230615142948_f6dc470</familie.kontrakter.version>
-        <familie.eksterne-kontrakter.stonadsstatistikk-ef>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.stonadsstatistikk-ef>
+        <familie.kontrakter.version>3.0_20230705132547_9303863</familie.kontrakter.version>
+        <familie.eksterne-kontrakter.stonadsstatistikk-ef>2.0_20230705125709_fdce40d</familie.eksterne-kontrakter.stonadsstatistikk-ef>
         <familie.eksterne-kontrakter.saksstatistikk-ef>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.saksstatistikk-ef>
         <familie.eksterne-kontrakter.arbeidsoppfolging>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.arbeidsoppfolging>
         <prosessering.version>2.20230322091650_fb0187e-SPRING_BOOT_3</prosessering.version>

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/transformer/IverksettDtoToDomain.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/transformer/IverksettDtoToDomain.kt
@@ -120,7 +120,6 @@ fun VedtaksperiodeSkolepengerDto.toDomain(): VedtaksperiodeSkolepenger {
         utgiftsperioder = this.utgiftsperioder.map {
             SkolepengerUtgift(
                 utgiftsdato = it.utgiftsdato,
-                utgifter = it.utgifter,
                 stønad = it.stønad,
             )
         },

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/domene/IverksettData.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/domene/IverksettData.kt
@@ -148,7 +148,6 @@ data class DelårsperiodeSkoleårSkolepenger(
 
 data class SkolepengerUtgift(
     val utgiftsdato: LocalDate,
-    val utgifter: Int,
     val stønad: Int,
 )
 

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkMapper.kt
@@ -256,7 +256,6 @@ object VedtakstatistikkMapper {
     private fun mapTilUtgiftSkolepenger(utgiftsperiode: SkolepengerUtgift) =
         UtgiftSkolepenger(
             utgiftsdato = utgiftsperiode.utgiftsdato,
-            utgiftsbeløp = utgiftsperiode.utgifter,
             utbetaltBeløp = utgiftsperiode.stønad,
         )
 

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/vedtakstatistikk/VedtakstatistikkMapperTest.kt
@@ -233,7 +233,6 @@ internal class VedtakstatistikkMapperTest {
         val mappetUtgiftsperiode = vedtakSkolepenger.vedtaksperioder.first().utgifter.first()
 
         assertThat(mappetUtgiftsperiode.utgiftsdato).isEqualTo(forventetUtgiftsperiode.utgiftsdato)
-        assertThat(mappetUtgiftsperiode.utgiftsbeløp).isEqualTo(forventetUtgiftsperiode.utgifter)
         assertThat(mappetUtgiftsperiode.utbetaltBeløp).isEqualTo(forventetUtgiftsperiode.stønad)
 
         assertThat(vedtakSkolepenger.kravMottatt).isEqualTo(LocalDate.of(2021, 3, 1))
@@ -312,7 +311,6 @@ internal class VedtakstatistikkMapperTest {
                 utgiftsperioder = listOf(
                     SkolepengerUtgift(
                         utgiftsdato = LocalDate.of(2021, 1, 1),
-                        utgifter = 5000,
                         stønad = 5000,
                     ),
                 ),


### PR DESCRIPTION
**Hvorfor?**
Ved overgang til nytt UI kommer saksbehandler ikke lengre til å oppgi utgifter, kun beløp til utbetaling. I ef-iverksett brukes utgifter bare til statistikk, og feltet kan derfor fjernes.

**PS:** Kan ikke merges før tommel opp fra datavarehus: https://nav-it.slack.com/archives/C0383QMSGUA/p1688554140206959