### PR TITLE
Ved iverksetting av gomregning skal grunnbeløp sendes med fra ef-sak,…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <kotlin.version>1.9.0</kotlin.version>
         <springdoc.version>2.1.0</springdoc.version>
         <felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
-        <familie.kontrakter.version>3.0_20230721145217_128807b</familie.kontrakter.version>
+        <familie.kontrakter.version>3.0_20230728094537_980f7a3</familie.kontrakter.version>
         <familie.eksterne-kontrakter.stonadsstatistikk-ef>2.0_20230721144943_b5151d2</familie.eksterne-kontrakter.stonadsstatistikk-ef>
         <familie.eksterne-kontrakter.saksstatistikk-ef>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.saksstatistikk-ef>
         <familie.eksterne-kontrakter.arbeidsoppfolging>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.arbeidsoppfolging>

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTask.kt
@@ -2,12 +2,12 @@ package no.nav.familie.ef.iverksett.brukernotifikasjon
 
 import no.nav.familie.ef.iverksett.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
+import no.nav.familie.ef.iverksett.iverksetting.domene.IverksettOvergangsstønad
 import no.nav.familie.ef.iverksett.repository.findByIdOrThrow
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import org.springframework.stereotype.Service
-import java.time.LocalDate
 import java.util.UUID
 
 @Service
@@ -25,20 +25,15 @@ class SendBrukernotifikasjonVedGOmregningTask(
     override fun doTask(task: Task) {
         val behandlingId = UUID.fromString(task.payload)
         val iverksett = iverksettingRepository.findByIdOrThrow(behandlingId).data
-        if (iverksett.erGOmregning() && featureToggleService.isEnabled("familie.ef.sak.g-beregning-scheduler")) { // Dobbeltsjekk: Tasken skal egentlig ikke være lagd hvis det ikke er G-omregning
-            if (nyesteGrunnbeløp.periode.fomDato.plusYears(1) > DatoUtil.dagensDato()) {
-                brukernotifikasjonKafkaProducer.sendBeskjedTilBruker(iverksett, behandlingId)
-            } else {
-                throw RuntimeException("Skal ikke sende melding til dittnav dersom grunnbeløpet ikke er oppdatert")
-            }
+        if (iverksett is IverksettOvergangsstønad &&
+            iverksett.erGOmregning() &&
+            featureToggleService.isEnabled("familie.ef.sak.g-beregning-scheduler")
+        ) { // Dobbeltsjekk: Tasken skal egentlig ikke være lagd hvis det ikke er G-omregning
+            brukernotifikasjonKafkaProducer.sendBeskjedTilBruker(iverksett, behandlingId)
         }
     }
 
     companion object {
         const val TYPE = "sendBrukernotifikasjonVedGOmregningTask"
     }
-}
-
-object DatoUtil { // For å kunne mocke dato
-    fun dagensDato() = LocalDate.now()
 }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/domene/IverksettData.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/domene/IverksettData.kt
@@ -19,6 +19,7 @@ import no.nav.familie.kontrakter.ef.felles.Vilkårsresultat
 import no.nav.familie.kontrakter.ef.iverksett.AdressebeskyttelseGradering
 import no.nav.familie.kontrakter.ef.iverksett.AktivitetType
 import no.nav.familie.kontrakter.ef.iverksett.BehandlingKategori
+import no.nav.familie.kontrakter.ef.iverksett.Grunnbeløp
 import no.nav.familie.kontrakter.ef.iverksett.IverksettBarnetilsynDto
 import no.nav.familie.kontrakter.ef.iverksett.IverksettDto
 import no.nav.familie.kontrakter.ef.iverksett.IverksettOvergangsstønadDto
@@ -189,6 +190,7 @@ data class VedtaksdetaljerOvergangsstønad(
     override val vedtaksperioder: List<VedtaksperiodeOvergangsstønad> = listOf(),
     override val avslagÅrsak: AvslagÅrsak? = null,
     val oppgaverForOpprettelse: OppgaverForOpprettelse = OppgaverForOpprettelse(oppgavetyper = emptyList()),
+    val grunnbeløp: Grunnbeløp? = null,
 ) : Vedtaksdetaljer()
 
 data class VedtaksdetaljerBarnetilsyn(

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/DomainTestUtil.kt
@@ -17,6 +17,7 @@ import no.nav.familie.kontrakter.ef.felles.BehandlingType
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.kontrakter.ef.felles.Vedtaksresultat
 import no.nav.familie.kontrakter.ef.iverksett.AndelTilkjentYtelseDto
+import no.nav.familie.kontrakter.ef.iverksett.Grunnbeløp
 import no.nav.familie.kontrakter.ef.iverksett.SimuleringDto
 import no.nav.familie.kontrakter.ef.iverksett.TilkjentYtelseDto
 import no.nav.familie.kontrakter.felles.Datoperiode
@@ -189,6 +190,7 @@ fun lagIverksettData(
     andeler: List<AndelTilkjentYtelse> = andelsdatoer.map {
         lagAndelTilkjentYtelse(beløp = 0, fraOgMed = it.minusMonths(1), tilOgMed = it, inntekt = 200_000)
     },
+    grunnbeløp: Grunnbeløp? = null,
 ): IverksettOvergangsstønad {
     val behandlingÅrsak = if (erMigrering) BehandlingÅrsak.MIGRERING else årsak
     return opprettIverksettOvergangsstønad(
@@ -203,6 +205,7 @@ fun lagIverksettData(
             andeler = andeler,
             startdato = andelsdatoer.minByOrNull { it } ?: YearMonth.now(),
             vedtaksTidspunkt = vedtakstidspunkt,
+            grunnbeløp = grunnbeløp,
         ),
     )
 }

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
@@ -6,9 +6,12 @@ import no.nav.brukernotifikasjon.schemas.input.NokkelInput
 import no.nav.familie.ef.iverksett.lagIverksettData
 import no.nav.familie.kontrakter.ef.felles.BehandlingType
 import no.nav.familie.kontrakter.ef.felles.Vedtaksresultat
+import no.nav.familie.kontrakter.ef.iverksett.Grunnbeløp
+import no.nav.familie.kontrakter.felles.Månedsperiode
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.kafka.core.KafkaTemplate
+import java.time.LocalDate
 import java.time.YearMonth
 
 class BrukernotifikasjonKafkaProducerTest {
@@ -16,16 +19,19 @@ class BrukernotifikasjonKafkaProducerTest {
     private val kafkaTemplate = mockk<KafkaTemplate<NokkelInput, BeskjedInput>>()
     private val brukernotifikasjonKafkaProducer = BrukernotifikasjonKafkaProducer(kafkaTemplate)
 
-    private val forventetGOmregningTekst = G_OMREGNING_MELDING_TIL_BRUKER
-
     @Test
     fun `lagBeskjed genererer riktig melding`() {
+        val forventetGOmregningTekst = "Fra 01.05.2023 har folketrygdens grunnbeløp økt til 118620 kroner og overgangsstønaden din er derfor endret."
         val iverksettRevurderingInnvilget = lagIverksettData(
             behandlingType = BehandlingType.REVURDERING,
             vedtaksresultat = Vedtaksresultat.INNVILGET,
             andelsdatoer = listOf(
                 YearMonth.now(),
                 YearMonth.now().plusMonths(1),
+            ),
+            grunnbeløp = Grunnbeløp(
+                periode = Månedsperiode(fom = YearMonth.of(2023, 5), tom = YearMonth.from(LocalDate.MAX)),
+                grunnbeløp = 118_620.toBigDecimal(),
             ),
         )
         Assertions.assertThat(brukernotifikasjonKafkaProducer.lagBeskjed(iverksettRevurderingInnvilget).getTekst()).isEqualTo(forventetGOmregningTekst)

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTaskTest.kt
@@ -3,9 +3,7 @@ package no.nav.familie.ef.iverksett.brukernotifikasjon
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkObject
 import io.mockk.runs
-import io.mockk.unmockkObject
 import io.mockk.verify
 import no.nav.familie.ef.iverksett.infrastruktur.transformer.toDomain
 import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
@@ -15,10 +13,8 @@ import no.nav.familie.ef.iverksett.util.mockFeatureToggleService
 import no.nav.familie.ef.iverksett.util.opprettIverksettDto
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.prosessering.domene.Task
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.time.LocalDate
 import java.util.UUID
 
 class SendBrukernotifikasjonVedGOmregningTaskTest {
@@ -29,16 +25,8 @@ class SendBrukernotifikasjonVedGOmregningTaskTest {
 
     @BeforeEach
     internal fun setUp() {
-        mockkObject(DatoUtil)
         every { iverksettingRepository.findByIdOrThrow(any()) }
             .returns(lagIverksett(opprettIverksettDto(behandlingId = UUID.randomUUID(), behandlingÅrsak = BehandlingÅrsak.G_OMREGNING).toDomain()))
-
-        every { DatoUtil.dagensDato() } returns LocalDate.of(2023, 3, 1)
-    }
-
-    @AfterEach
-    internal fun tearDown() {
-        unmockkObject(DatoUtil)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/util/IverksettMockUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/util/IverksettMockUtil.kt
@@ -49,6 +49,7 @@ import no.nav.familie.kontrakter.ef.iverksett.AktivitetType
 import no.nav.familie.kontrakter.ef.iverksett.BehandlingsdetaljerDto
 import no.nav.familie.kontrakter.ef.iverksett.DelvilkårsvurderingDto
 import no.nav.familie.kontrakter.ef.iverksett.FagsakdetaljerDto
+import no.nav.familie.kontrakter.ef.iverksett.Grunnbeløp
 import no.nav.familie.kontrakter.ef.iverksett.IverksettOvergangsstønadDto
 import no.nav.familie.kontrakter.ef.iverksett.OppgaveForOpprettelseType
 import no.nav.familie.kontrakter.ef.iverksett.OppgaverForOpprettelseDto
@@ -243,6 +244,7 @@ fun vedtaksdetaljerOvergangsstønad(
     vedtaksTidspunkt: LocalDateTime = LocalDateTime.of(2021, 5, 12, 0, 0),
     inntekt: Boolean = true,
     oppgaverForOpprettelse: OppgaverForOpprettelse = OppgaverForOpprettelse(listOf(OppgaveForOpprettelseType.INNTEKTSKONTROLL_1_ÅR_FREM_I_TID)),
+    grunnbeløp: Grunnbeløp? = null,
 ): VedtaksdetaljerOvergangsstønad {
     val tilkjentYtelse = lagTilkjentYtelse(andeler, startdato)
     return VedtaksdetaljerOvergangsstønad(
@@ -256,6 +258,7 @@ fun vedtaksdetaljerOvergangsstønad(
         tilbakekreving = tilbakekreving,
         brevmottakere = Brevmottakere(emptyList()),
         oppgaverForOpprettelse = oppgaverForOpprettelse,
+        grunnbeløp = grunnbeløp,
     )
 }
 

--- a/src/test/resources/json/IverksettDtoEksempel.json
+++ b/src/test/resources/json/IverksettDtoEksempel.json
@@ -118,6 +118,7 @@
     "avslagÅrsak":null,
     "oppgaverForOpprettelse": {
       "oppgavetyper": ["INNTEKTSKONTROLL_1_ÅR_FREM_I_TID"]
-    }
+    },
+    "grunnbeløp": null
   }
 }


### PR DESCRIPTION
… og brukes ved publisering av melding til bruker

### Hvorfor?
Fortsettelse på https://github.com/navikt/familie-ef-sak/pull/2330

Når vi iverksetter en behandling med behandlingsårsak GOmregning publiserer familie-ef-iverksett en melding til bruker med informasjon om Gomregningen (SendBrukernotifikasjonVedGOmregningTask). Frem til nå har vi bare hardkodet nyeste grunnbeløp i iverksett. Ulempen med dette er at vi hvert år må huske å oppdatere iverksett med nyeste G. Ved å sende det G med fra ef-sak slipper vi å ha dette i iverksett, og vi kan være sikre på at det brukes riktig grunnbeløp i melding til bruker.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-13586)