### PR TITLE
Ny utbetalingsgenerator kontroll av simuleringsresultat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <familie.eksterne-kontrakter.saksstatistikk-ef>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.saksstatistikk-ef>
         <familie.eksterne-kontrakter.arbeidsoppfolging>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.arbeidsoppfolging>
         <prosessering.version>2.20230713120621_747ed8f</prosessering.version>
-        <utbetalingsgenerator.version>1.0_20230629085807_aca8dc9</utbetalingsgenerator.version>
+        <utbetalingsgenerator.version>1.0_20230801144343_5d8629f</utbetalingsgenerator.version>
         <brukernotifikasjon-schemas.version>2.5.2</brukernotifikasjon-schemas.version>
         <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
         <confluent.version>7.4.1</confluent.version>

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/configuration/DatabaseConfiguration.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/configuration/DatabaseConfiguration.kt
@@ -13,6 +13,8 @@ import no.nav.familie.ef.iverksett.iverksetting.domene.IverksettSkolepenger
 import no.nav.familie.ef.iverksett.iverksetting.domene.OppdragResultat
 import no.nav.familie.ef.iverksett.iverksetting.domene.TilbakekrevingResultat
 import no.nav.familie.ef.iverksett.iverksetting.domene.TilkjentYtelse
+import no.nav.familie.ef.iverksett.økonomi.simulering.kontroll.SimuleringskontrollInput
+import no.nav.familie.ef.iverksett.økonomi.simulering.kontroll.SimuleringskontrollResultat
 import no.nav.familie.eksterne.kontrakter.saksstatistikk.ef.BehandlingDVH
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.objectMapper
@@ -66,6 +68,11 @@ class DatabaseConfiguration : AbstractJdbcConfiguration() {
                 StringTilBrevmottakereConverter(),
                 YearTilLocalDateConverter(),
                 LocalDateTilYearConverter(),
+
+                SimuleringskontrollInputTilStringConverter(),
+                StringTilSimuleringskontrollInputConverter(),
+                SimuleringskontrollResultatTilStringConverter(),
+                StringTilSimuleringskontrollResultatConverter(),
             ),
         )
     }
@@ -90,7 +97,11 @@ class DatabaseConfiguration : AbstractJdbcConfiguration() {
             val fagsakdetaljer: Fagsakdetaljer = objectMapper.treeToValue(fagsakNode)
             return when (fagsakdetaljer.stønadstype) {
                 StønadType.BARNETILSYN -> objectMapper.readValue(pGobject.value, IverksettBarnetilsyn::class.java)
-                StønadType.OVERGANGSSTØNAD -> objectMapper.readValue(pGobject.value, IverksettOvergangsstønad::class.java)
+                StønadType.OVERGANGSSTØNAD -> objectMapper.readValue(
+                    pGobject.value,
+                    IverksettOvergangsstønad::class.java,
+                )
+
                 StønadType.SKOLEPENGER -> objectMapper.readValue(pGobject.value, IverksettSkolepenger::class.java)
             }
         }
@@ -200,6 +211,42 @@ class DatabaseConfiguration : AbstractJdbcConfiguration() {
 
         override fun convert(date: Date): Year {
             return Year.from(date.toLocalDate())
+        }
+    }
+
+    @WritingConverter
+    class SimuleringskontrollInputTilStringConverter : Converter<SimuleringskontrollInput, PGobject> {
+
+        override fun convert(data: SimuleringskontrollInput): PGobject =
+            PGobject().apply {
+                type = "json"
+                value = objectMapper.writeValueAsString(data)
+            }
+    }
+
+    @ReadingConverter
+    class StringTilSimuleringskontrollInputConverter : Converter<PGobject, SimuleringskontrollInput> {
+
+        override fun convert(pgObject: PGobject): SimuleringskontrollInput {
+            return objectMapper.readValue(pgObject.value!!)
+        }
+    }
+
+    @WritingConverter
+    class SimuleringskontrollResultatTilStringConverter : Converter<SimuleringskontrollResultat, PGobject> {
+
+        override fun convert(data: SimuleringskontrollResultat): PGobject =
+            PGobject().apply {
+                type = "json"
+                value = objectMapper.writeValueAsString(data)
+            }
+    }
+
+    @ReadingConverter
+    class StringTilSimuleringskontrollResultatConverter : Converter<PGobject, SimuleringskontrollResultat> {
+
+        override fun convert(pgObject: PGobject): SimuleringskontrollResultat {
+            return objectMapper.readValue(pgObject.value!!)
         }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/kontroll/SimuleringskontrollRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/kontroll/SimuleringskontrollRepository.kt
@@ -1,0 +1,33 @@
+package no.nav.familie.ef.iverksett.økonomi.simulering.kontroll
+
+import no.nav.familie.ef.iverksett.iverksetting.domene.Simulering
+import no.nav.familie.ef.iverksett.repository.InsertUpdateRepository
+import no.nav.familie.ef.iverksett.repository.RepositoryInterface
+import no.nav.familie.kontrakter.felles.simulering.BeriketSimuleringsresultat
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface SimuleringskontrollRepository :
+    RepositoryInterface<Simuleringskontroll, UUID>,
+    InsertUpdateRepository<Simuleringskontroll>
+
+data class Simuleringskontroll(
+    @Id
+    val behandlingId: UUID,
+    @Column("input")
+    val input: SimuleringskontrollInput,
+    @Column("resultat")
+    val resultat: SimuleringskontrollResultat,
+)
+
+data class SimuleringskontrollInput(
+    val simulering: Simulering,
+    val resultat: BeriketSimuleringsresultat,
+)
+
+data class SimuleringskontrollResultat(
+    val resultat: BeriketSimuleringsresultat,
+)

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/kontroll/SimuleringskontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/kontroll/SimuleringskontrollService.kt
@@ -1,0 +1,133 @@
+package no.nav.familie.ef.iverksett.økonomi.simulering.kontroll
+
+import no.nav.familie.ef.iverksett.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.iverksett.iverksetting.domene.IverksettData
+import no.nav.familie.ef.iverksett.iverksetting.domene.Simulering
+import no.nav.familie.ef.iverksett.iverksetting.domene.tilSimulering
+import no.nav.familie.ef.iverksett.økonomi.simulering.SimuleringService
+import no.nav.familie.kontrakter.felles.simulering.BeriketSimuleringsresultat
+import no.nav.familie.kontrakter.felles.simulering.Simuleringsperiode
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.time.YearMonth
+import java.util.UUID
+
+@Service
+class SimuleringskontrollService(
+    private val simuleringService: SimuleringService,
+    private val simuleringskontrollRepository: SimuleringskontrollRepository,
+    private val featureToggleService: FeatureToggleService,
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    fun kontrollerMedNyUtbetalingsgenerator(
+        iverksett: IverksettData,
+        beriketSimuleringsresultatFn: () -> BeriketSimuleringsresultat,
+    ) {
+        if (!featureToggleService.isEnabled("familie.ef.iverksett.simuleringskontroll")) {
+            return
+        }
+        if (iverksett.behandling.forrigeBehandlingId == null) {
+            return
+        }
+        val beriketSimuleringsresultat = beriketSimuleringsresultatFn()
+        val simulering = iverksett.tilSimulering()
+
+        val behandlingId = iverksett.behandling.behandlingId
+        try {
+            simulerMedNyUtbetalingsgeneratorOgSjekkDif(simulering, beriketSimuleringsresultat)
+        } catch (e: Exception) {
+            logger.warn("Feilet kontroll av behandling=$behandlingId")
+        }
+    }
+
+    private fun simulerMedNyUtbetalingsgeneratorOgSjekkDif(
+        simulering: Simulering,
+        beriketSimuleringsresultat: BeriketSimuleringsresultat,
+    ) {
+        val behandlingId = simulering.nyTilkjentYtelseMedMetaData.behandlingId
+        val simuleringNyUtbetalingsgenerator =
+            simuleringService.hentBeriketSimulering(simulering, brukNyUtbetalingsgenerator = true)
+        val tidligerePerioder = beriketSimuleringsresultat.oppsummering.perioder.sortedBy { it.fom }
+        val nyePerioder = simuleringNyUtbetalingsgenerator.oppsummering.perioder.sortedBy { it.fom }
+
+        val harDiff = harDiff(behandlingId, tidligerePerioder, nyePerioder)
+        if (harDiff) {
+            val resultat = SimuleringskontrollResultat(simuleringNyUtbetalingsgenerator)
+            val input = SimuleringskontrollInput(simulering, beriketSimuleringsresultat)
+            simuleringskontrollRepository.insert(Simuleringskontroll(behandlingId, input, resultat))
+        }
+    }
+
+    private fun harDiff(
+        behandlingId: UUID,
+        tidligerePerioder: List<Simuleringsperiode>,
+        nyePerioder: List<Simuleringsperiode>,
+    ): Boolean {
+        var harDiff = false
+
+        val tidligereFørstePeriode = tidligerePerioder.firstOrNull()
+        val nyFørstePeriode = nyePerioder.firstOrNull()
+        if (tidligereFørstePeriode == null || nyFørstePeriode == null) {
+            logger.info(
+                "behandlingId=$behandlingId - kjørerIkkeKontroll" +
+                    " tidligereFørstePeriodeErNull=${tidligereFørstePeriode == null}" +
+                    " nyFørstePeriodeErNull=${nyFørstePeriode == null}",
+            )
+            return false
+        }
+
+        tidligerePerioder
+            .filter { it.tom < nyFørstePeriode.fom }
+            .filter { it.resultat.harDiff() }
+            .takeIf { it.isNotEmpty() }
+            ?.run {
+                logger.warn("behandlingId=$behandlingId - Har diff i resultat før ny simuleringsendring")
+                harDiff = true
+            }
+
+        val tidligerePerioderMap =
+            extracted(tidligerePerioder).filterKeys { it >= YearMonth.from(nyFørstePeriode.fom) }
+        val nyePerioderMap = extracted(nyePerioder)
+
+        nyePerioderMap.forEach { (måned, nyttResultat) ->
+            val tidligereResultat = tidligerePerioderMap[måned]
+            if (tidligereResultat != null && tidligereResultat != nyttResultat) {
+                logger.warn("behandlingId=$behandlingId - måned=$måned forrigeVerdi=$tidligereResultat nyttVerdi=$nyttResultat")
+                harDiff = true
+            }
+        }
+        if (nyePerioderMap.size != tidligerePerioderMap.size) {
+            logger.warn("behandlingId=$behandlingId - diff i antall måneder")
+            harDiff = true
+        }
+        return harDiff
+    }
+
+    private fun extracted(tidligerePerioder: List<Simuleringsperiode>): Map<YearMonth, Int> {
+        val map = mutableMapOf<YearMonth, Int>()
+        tidligerePerioder.forEach { periode ->
+            periode.split().forEach {
+                val previous = map.put(it.first, it.second)
+                if (previous != null) {
+                    logger.error("Har flere verdier for ${it.first}")
+                }
+            }
+        }
+        return map
+    }
+}
+
+private fun Simuleringsperiode.split(): List<Pair<YearMonth, Int>> {
+    val perioder = mutableListOf<Pair<YearMonth, Int>>()
+    var måned = YearMonth.from(this.fom)
+    while (måned <= YearMonth.from(this.tom)) {
+        perioder.add(Pair(måned, this.resultat.toInt()))
+        måned = måned.plusMonths(1)
+    }
+    return perioder
+}
+
+private fun BigDecimal.harDiff() = this.compareTo(BigDecimal.ZERO) != 0

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/kontroll/SimuleringskontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/kontroll/SimuleringskontrollService.kt
@@ -59,6 +59,7 @@ class SimuleringskontrollService(
             val input = SimuleringskontrollInput(simulering, beriketSimuleringsresultat)
             simuleringskontrollRepository.insert(Simuleringskontroll(behandlingId, input, resultat))
         }
+        logger.info("behandling=$behandlingId - kontroll av ny utbetalingsgenerator utført - harDiff=$harDiff")
     }
 
     private fun harDiff(

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -298,12 +298,6 @@ object UtbetalingsoppdragGenerator {
         }
     }
 
-    private fun sistePeriodeId(tilkjentYtelse: TilkjentYtelse?): PeriodeId? {
-        return tilkjentYtelse?.let { ytelse ->
-            ytelse.sisteAndelIKjede?.tilPeriodeId()
-                // TODO denne kan fjernes når den er patchet
-                ?: ytelse.andelerTilkjentYtelse.filter { it.periodeId != null }.maxByOrNull { it.periodeId!! }
-                    ?.tilPeriodeId()
-        }
-    }
+    private fun sistePeriodeId(tilkjentYtelse: TilkjentYtelse?): PeriodeId? =
+        tilkjentYtelse?.sisteAndelIKjede?.tilPeriodeId()
 }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/UtbetalingsoppdragGenerator.kt
@@ -94,13 +94,19 @@ object UtbetalingsoppdragGenerator {
     }
 
     /**
+     * Id brukes ikke til noe spesielt for siste andel i kjeden, men er en del av [AndelData]
+     * Settes til noe random.
+     */
+    private val idSisteAndelIKjeden = "SISTE_ANDEL_I_KJEDEN"
+
+    /**
      * Utbetalingsgeneratorn ønsker en map med ident og type, då den har støtte for å sende inn flere personer som brukes av Barnetrygd
      */
     private fun mapTilSisteAndelPerKjede(
         forrigeSisteAndelIKjede: AndelTilkjentYtelse?,
         personIdent: String,
         ytelseType: YtelseType,
-    ) = forrigeSisteAndelIKjede?.tilAndelData("-1", personIdent, ytelseType)
+    ) = forrigeSisteAndelIKjede?.tilAndelData(idSisteAndelIKjeden, personIdent, ytelseType)
         ?.let { mapOf(IdentOgType(personIdent, ytelseType) to it) } ?: emptyMap()
 
     private fun behandlingsinformasjon(

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/ØkonomiUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/økonomi/utbetalingsoppdrag/ØkonomiUtils.kt
@@ -18,7 +18,6 @@ data class PeriodeId(
 
 fun AndelTilkjentYtelse.tilPeriodeId(): PeriodeId = PeriodeId(this.periodeId, this.forrigePeriodeId)
 
-// TODO må håndtere denne i nye utbetalingsgeneratorn
 fun nullAndelTilkjentYtelse(kildeBehandlingId: UUID, periodeId: PeriodeId?): AndelTilkjentYtelse =
     AndelTilkjentYtelse(
         beløp = 0,

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/OpprettTilbakekrevingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/OpprettTilbakekrevingTaskTest.kt
@@ -45,6 +45,7 @@ internal class OpprettTilbakekrevingTaskTest {
         tilbakekrevingClient = tilbakekrevingClient,
         simuleringService = simuleringService,
         familieIntegrasjonerClient = familieIntegrasjonerClient,
+        simuleringskontrollService = mockk(relaxed = true),
     )
 
     @BeforeEach

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/kontroll/SimuleringskontrollRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/kontroll/SimuleringskontrollRepositoryTest.kt
@@ -1,0 +1,29 @@
+package no.nav.familie.ef.iverksett.økonomi.simulering.kontroll
+
+import no.nav.familie.ef.iverksett.ServerTest
+import no.nav.familie.ef.iverksett.beriketSimuleringsresultat
+import no.nav.familie.ef.iverksett.iverksetting.domene.Simulering
+import no.nav.familie.ef.iverksett.repository.findByIdOrThrow
+import no.nav.familie.ef.iverksett.util.opprettTilkjentYtelseMedMetadata
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.util.UUID
+
+class SimuleringskontrollRepositoryTest : ServerTest() {
+
+    @Autowired
+    lateinit var repository: SimuleringskontrollRepository
+
+    @Test
+    fun `lagring og henting av data`() {
+        val behandlingId = UUID.randomUUID()
+        val input = SimuleringskontrollInput(Simulering(opprettTilkjentYtelseMedMetadata(), UUID.randomUUID()), beriketSimuleringsresultat())
+        val resultat = SimuleringskontrollResultat(beriketSimuleringsresultat())
+        val simuleringskontroll = repository.insert(Simuleringskontroll(behandlingId, input, resultat))
+
+        val hentetSimuleringskontroll = repository.findByIdOrThrow(behandlingId)
+
+        assertThat(hentetSimuleringskontroll).isEqualTo(simuleringskontroll)
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/kontroll/SimuleringskontrollServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/kontroll/SimuleringskontrollServiceTest.kt
@@ -142,7 +142,9 @@ class SimuleringskontrollServiceTest {
             feilutbetaling = BigDecimal.ZERO,
         )
 
-    private fun getLogmeldinger() = logWatcher.list.map { it.formattedMessage }
+    private fun getLogmeldinger() =
+        logWatcher.list.map { it.formattedMessage }
+            .filterNot { it.contains("kontroll av ny utbetalingsgenerator utført") }
 
     private fun kontroller(data: IverksettOvergangsstønad, tidligereSimuleringsperioder: List<Simuleringsperiode>) {
         service.kontrollerMedNyUtbetalingsgenerator(data) { lagBeriketSimuleringsresultat(tidligereSimuleringsperioder) }

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/kontroll/SimuleringskontrollServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/økonomi/simulering/kontroll/SimuleringskontrollServiceTest.kt
@@ -1,0 +1,166 @@
+package no.nav.familie.ef.iverksett.økonomi.simulering.kontroll
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.ef.iverksett.detaljertSimuleringResultat
+import no.nav.familie.ef.iverksett.iverksetting.domene.IverksettOvergangsstønad
+import no.nav.familie.ef.iverksett.lagIverksettData
+import no.nav.familie.ef.iverksett.simuleringsoppsummering
+import no.nav.familie.ef.iverksett.util.mockFeatureToggleService
+import no.nav.familie.ef.iverksett.økonomi.simulering.SimuleringService
+import no.nav.familie.kontrakter.ef.felles.BehandlingType
+import no.nav.familie.kontrakter.ef.felles.Vedtaksresultat
+import no.nav.familie.kontrakter.felles.simulering.BeriketSimuleringsresultat
+import no.nav.familie.kontrakter.felles.simulering.Simuleringsperiode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.YearMonth
+import java.util.UUID
+
+class SimuleringskontrollServiceTest {
+
+    private var logWatcher = ListAppender<ILoggingEvent>()
+
+    private val simuleringService = mockk<SimuleringService>()
+
+    private val simuleringskontrollRepository = mockk<SimuleringskontrollRepository>()
+
+    private val service = SimuleringskontrollService(
+        simuleringService,
+        simuleringskontrollRepository,
+        mockFeatureToggleService(),
+    )
+
+    private val JAN = YearMonth.of(2023, 1)
+    private val FEB = YearMonth.of(2023, 2)
+    private val MARS = YearMonth.of(2023, 3)
+
+    @BeforeEach
+    fun setUp() {
+        logWatcher = ListAppender()
+        (LoggerFactory.getLogger(SimuleringskontrollService::class.java) as Logger).addAppender(logWatcher)
+        logWatcher.start()
+        every { simuleringskontrollRepository.insert(any()) } answers { firstArg() }
+    }
+
+    @Test
+    fun `skal ikke lagre noe når listene er empty`() {
+        kontroller(emptyList(), emptyList())
+
+        val logmeldinger = getLogmeldinger()
+        assertThat(logmeldinger).hasSize(1)
+        assertThat(logmeldinger[0]).contains("tidligereFørstePeriodeErNull=true nyFørstePeriodeErNull=true")
+
+        verify(exactly = 0) { simuleringskontrollRepository.insert(any()) }
+    }
+
+    @Test
+    fun `skal lagre data når det er diff på resultat før første endring i ny simulering`() {
+        val tidligerePerioder = listOf(simuleringsperiode(JAN, 10), simuleringsperiode(FEB, 10))
+        val nyePerioder = listOf(simuleringsperiode(FEB, 10))
+
+        kontroller(tidligerePerioder, nyePerioder)
+
+        val logmeldinger = getLogmeldinger()
+        assertThat(logmeldinger).hasSize(1)
+        assertThat(logmeldinger[0]).contains("Har diff i resultat før ny simuleringsendring")
+
+        verify(exactly = 1) { simuleringskontrollRepository.insert(any()) }
+    }
+
+    @Test
+    fun `skal lagre data når det er diff på beløp på en måned`() {
+        val tidligerePerioder = listOf(simuleringsperiode(FEB, 20))
+        val nyePerioder = listOf(simuleringsperiode(FEB, 10))
+
+        kontroller(tidligerePerioder, nyePerioder)
+
+        val logmeldinger = getLogmeldinger()
+        assertThat(logmeldinger).hasSize(1)
+        assertThat(logmeldinger[0]).contains("måned=2023-02 forrigeVerdi=20 nyttVerdi=10")
+
+        verify(exactly = 1) { simuleringskontrollRepository.insert(any()) }
+    }
+
+    @Test
+    fun `skal lagre data når tidligere resultatet mangler verdier`() {
+        val tidligerePerioder = listOf(simuleringsperiode(FEB, 10))
+        val nyePerioder = listOf(simuleringsperiode(FEB, 10), simuleringsperiode(MARS, 20))
+
+        kontroller(tidligerePerioder, nyePerioder)
+
+        val logmeldinger = getLogmeldinger()
+        assertThat(logmeldinger).hasSize(1)
+        assertThat(logmeldinger[0]).contains("diff i antall måneder")
+
+        verify(exactly = 1) { simuleringskontrollRepository.insert(any()) }
+    }
+
+    @Test
+    fun `skal lagre data når nye resultatet mangler verdier`() {
+        val tidligerePerioder = listOf(simuleringsperiode(FEB, 10), simuleringsperiode(MARS, 20))
+        val nyePerioder = listOf(simuleringsperiode(FEB, 10))
+
+        kontroller(tidligerePerioder, nyePerioder)
+
+        val logmeldinger = getLogmeldinger()
+        assertThat(logmeldinger).hasSize(1)
+        assertThat(logmeldinger[0]).contains("diff i antall måneder")
+
+        verify(exactly = 1) { simuleringskontrollRepository.insert(any()) }
+    }
+
+    private fun kontroller(
+        tidligerePerioder: List<Simuleringsperiode>,
+        nyePerioder: List<Simuleringsperiode>,
+    ) {
+        every {
+            simuleringService.hentBeriketSimulering(any(), any())
+        } returns lagBeriketSimuleringsresultat(nyePerioder)
+
+        val data = iverksettData()
+
+        kontroller(data, tidligerePerioder)
+    }
+
+    private fun simuleringsperiode(måned: YearMonth, beløp: Int) =
+        Simuleringsperiode(
+            fom = måned.atDay(1),
+            tom = måned.atEndOfMonth(),
+            forfallsdato = LocalDate.now(),
+            nyttBeløp = BigDecimal.ZERO,
+            tidligereUtbetalt = BigDecimal.ZERO,
+            resultat = beløp.toBigDecimal(),
+            feilutbetaling = BigDecimal.ZERO,
+        )
+
+    private fun getLogmeldinger() = logWatcher.list.map { it.formattedMessage }
+
+    private fun kontroller(data: IverksettOvergangsstønad, tidligereSimuleringsperioder: List<Simuleringsperiode>) {
+        service.kontrollerMedNyUtbetalingsgenerator(data) { lagBeriketSimuleringsresultat(tidligereSimuleringsperioder) }
+    }
+
+    private fun lagBeriketSimuleringsresultat(perioder: List<Simuleringsperiode>): BeriketSimuleringsresultat {
+        return BeriketSimuleringsresultat(
+            detaljer = detaljertSimuleringResultat(),
+            oppsummering = simuleringsoppsummering().copy(perioder = perioder),
+        )
+    }
+
+    private fun iverksettData(): IverksettOvergangsstønad {
+        return lagIverksettData(
+            forrigeBehandlingId = UUID.randomUUID(),
+            behandlingType = BehandlingType.REVURDERING,
+            vedtaksresultat = Vedtaksresultat.INNVILGET,
+            andeler = emptyList(),
+        )
+    }
+}


### PR DESCRIPTION
Den nye utbetalingsgeneratorn blir kun brukt i OpprettTilbakekrevingTask, som simulerer den nye kjeden med gammel og ny utbetalingsgenerator. Hvis det er diff så logger den typen diff, og lagrer input og output til databasen.

Dette er for å kontrollere at det blir likt resultat før den tas i bruk.

Fortsettelse på https://github.com/navikt/familie-ef-iverksett/pull/806

Logger fra kontroll: 
https://logs.adeo.no/s/nav-logs-legacy/app/r/s/lyWXp