### PR TITLE
Regler for inntektsjekk dato

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/felles/util/DatoUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/felles/util/DatoUtil.kt
@@ -14,6 +14,7 @@ object DatoFormat {
 object DatoUtil {
 
     fun dagensDatoMedTid(): LocalDateTime = LocalDateTime.now()
+    fun dagensDato(): LocalDate = LocalDate.now()
 }
 
 fun dagensDatoNorskFormat(): String = LocalDate.now().format(DatoFormat.DATE_FORMAT_NORSK)

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveService.kt
@@ -83,7 +83,7 @@ class OppgaveService(
                 oppgavetype = Oppgavetype.Fremlegg,
                 beskrivelse = beskrivelse,
                 settBehandlesAvApplikasjon = false,
-                fristFerdigstillelse = lagFristFerdigstillelseInntektsjekk(iverksett.vedtak.vedtakstidspunkt.toLocalDate()),
+                fristFerdigstillelse = lagFristFerdigstillelseFremleggsoppgaver(iverksett.vedtak.vedtakstidspunkt.toLocalDate()),
                 mappeId = finnMappeForFremleggsoppgave(iverksett.søker.tilhørendeEnhet, iverksett.behandling.behandlingId),
             )
 
@@ -91,10 +91,13 @@ class OppgaveService(
             ?: error("Kunne ikke finne oppgave for behandlingId=${iverksett.behandling.behandlingId}")
     }
 
-    fun lagFristFerdigstillelseInntektsjekk(vedtaksdato: LocalDate): LocalDate? {
-        // Skal ikke falle på den 6. hver måned
-        // 17. og 18. mai
-        // ikke juli eller august
+    fun lagFristFerdigstillelseFremleggsoppgaver(vedtaksdato: LocalDate): LocalDate? {
+        // Frist skal ikke falle på
+        // - Den 6. dagen i måneden for det er en rutine i enhetene som sier at hvis man ikke får revurdert eller sjekket en sak fordi inntekten for den siste måneden ikke er innrapportert ennå, så oppretter man en fremleggsoppgave med frist den 6. neste måned for å sjekke inntekten. Grunnen til at fristen er den 6. er fordi arbeidsgivers frist til å innrapportere inntekt for forrige måned er den 5.
+        // - 17. og 18. mai, for de er forbeholdt karakterutskriftsoppgavene
+        // - Juli og august på grunn av ferie og lav bemanning
+        // Det er verdt å merke seg at oppgavesystemet flytter fristen fremover dersom fristdato lander på en helg.
+
         var ettÅrFremITid = vedtaksdato.plusYears(1)
 
         if (ettÅrFremITid.monthValue == 7 || ettÅrFremITid.monthValue == 8) ettÅrFremITid = ettÅrFremITid.minusMonths(2)

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveService.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ef.iverksett.oppgave
 
 import no.nav.familie.ef.iverksett.felles.FamilieIntegrasjonerClient
-import no.nav.familie.ef.iverksett.felles.util.DatoUtil
 import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
 import no.nav.familie.ef.iverksett.iverksetting.domene.IverksettOvergangsstønad
 import no.nav.familie.ef.iverksett.iverksetting.domene.VedtaksperiodeOvergangsstønad
@@ -15,7 +14,6 @@ import no.nav.familie.kontrakter.ef.felles.BehandlingType
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.kontrakter.ef.felles.Vedtaksresultat
 import no.nav.familie.kontrakter.ef.iverksett.VedtaksperiodeType
-import no.nav.familie.kontrakter.felles.Datoperiode
 import no.nav.familie.kontrakter.felles.oppgave.MappeDto
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
@@ -97,24 +95,11 @@ class OppgaveService(
         // Skal ikke falle på den 6. hver måned
         // 17. og 18. mai
         // ikke juli eller august
-        val ugyldigePerioder =
-            listOf(
-                Datoperiode(
-                    LocalDate.of(DatoUtil.dagensDato().year + 1, 7, 1),
-                    LocalDate.of(DatoUtil.dagensDato().year + 1, 8, 31),
-                ),
-                Datoperiode(
-                    LocalDate.of(DatoUtil.dagensDato().year + 1, 5, 17),
-                    LocalDate.of(DatoUtil.dagensDato().year + 1, 5, 18),
-                ),
-            )
-
         var ettÅrFremITid = vedtaksdato.plusYears(1)
-        ettÅrFremITid = ugyldigePerioder.firstOrNull { it.inneholder(ettÅrFremITid) }?.fom?.minusDays(1) ?: ettÅrFremITid
 
-        if (ettÅrFremITid.dayOfMonth == 6) {
-            return ettÅrFremITid.minusDays(1)
-        }
+        if (ettÅrFremITid.monthValue == 7 || ettÅrFremITid.monthValue == 8) ettÅrFremITid = ettÅrFremITid.minusMonths(2)
+        if (ettÅrFremITid.monthValue == 5 && (ettÅrFremITid.dayOfMonth == 17 || ettÅrFremITid.dayOfMonth == 18)) ettÅrFremITid = ettÅrFremITid.minusDays(2)
+        if (ettÅrFremITid.dayOfMonth == 6) ettÅrFremITid = ettÅrFremITid.minusDays(1)
 
         return ettÅrFremITid
     }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveService.kt
@@ -99,7 +99,7 @@ class OppgaveService(
 
         if (ettÅrFremITid.monthValue == 7 || ettÅrFremITid.monthValue == 8) ettÅrFremITid = ettÅrFremITid.minusMonths(2)
         if (ettÅrFremITid.monthValue == 5 && (ettÅrFremITid.dayOfMonth == 17 || ettÅrFremITid.dayOfMonth == 18)) ettÅrFremITid = ettÅrFremITid.minusDays(2)
-        if (ettÅrFremITid.dayOfMonth == 6) ettÅrFremITid = ettÅrFremITid.minusDays(1)
+        if (ettÅrFremITid.dayOfMonth == 6) ettÅrFremITid = ettÅrFremITid.plusDays(1)
 
         return ettÅrFremITid
     }

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/cucumber/domeneparser/BasisDomeneParser.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/cucumber/domeneparser/BasisDomeneParser.kt
@@ -73,7 +73,7 @@ fun parseValgfriBoolean(domenebegrep: Domenenøkkel, rad: Map<String, String?>):
     }
 }
 
-private fun parseDato(dato: String): LocalDate {
+fun parseDato(dato: String): LocalDate {
     return if (dato.contains(".")) {
         LocalDate.parse(dato, norskDatoFormatter)
     } else {

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/cucumber/steps/StepDefinitions.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/cucumber/steps/StepDefinitions.kt
@@ -70,10 +70,12 @@ class StepDefinitions {
     fun `lagTilkjentYtelseMedUtbetalingsoppdrag kjøres kastes exception`() {
         catchThrowable { `andelhistorikk kjøres`() }
     }
+
     @Når("lag frist for ferdigstillelse av inntektsjekk")
     fun `lag frist for ferdigstillelse av inntektsjekk`() {
         fristForInntektsjekk = OppgaveService(mockk(), mockk(), mockk()).lagFristFerdigstillelseInntektsjekk(vedtaksdato)
     }
+
     @Når("lagTilkjentYtelseMedUtbetalingsoppdrag kjøres")
     fun `andelhistorikk kjøres`() {
         beregnedeTilkjentYtelse = tilkjentYtelse.fold(emptyList<Pair<UUID, TilkjentYtelse>>()) { acc, holder ->
@@ -90,6 +92,7 @@ class StepDefinitions {
     fun `forvent følgende frist`(forventetFrist: String) {
         assertThat(fristForInntektsjekk).isEqualTo(parseDato(forventetFrist))
     }
+
     @Så("forvent følgende utbetalingsoppdrag uten utbetalingsperiode")
     fun `forvent følgende utbetalingsoppdrag uten utbetalingsperiode`(dataTable: DataTable) {
         val forventedeUtbetalingsoppdrag = TilkjentYtelseParser.mapForventetUtbetalingsoppdrag(dataTable, false)

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/cucumber/steps/StepDefinitions.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/cucumber/steps/StepDefinitions.kt
@@ -73,7 +73,7 @@ class StepDefinitions {
 
     @Når("lag frist for ferdigstillelse av inntektsjekk")
     fun `lag frist for ferdigstillelse av inntektsjekk`() {
-        fristForInntektsjekk = OppgaveService(mockk(), mockk(), mockk()).lagFristFerdigstillelseInntektsjekk(vedtaksdato)
+        fristForInntektsjekk = OppgaveService(mockk(), mockk(), mockk()).lagFristFerdigstillelseFremleggsoppgaver(vedtaksdato)
     }
 
     @Når("lagTilkjentYtelseMedUtbetalingsoppdrag kjøres")

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveServiceTest.kt
@@ -461,25 +461,41 @@ internal class OppgaveServiceTest {
 
     @Test
     fun `lovlig frist for inntektsjekk skal ikke fremskyndes`() {
-        val frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 9,1))
+        val frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 9, 1))
         assertThat(frist).isEqualTo((LocalDate.of(LocalDate.now().year + 1, 9, 1)))
     }
 
     @Test
     fun `frist for inntektsjekk skal ikke være 17 eller 18 mai`() {
-        val frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 5,18))
+        var frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 5, 17))
+        assertThat(frist).isEqualTo((LocalDate.of(LocalDate.now().year + 1, 5, 15)))
+
+        frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 5, 18))
         assertThat(frist).isEqualTo((LocalDate.of(LocalDate.now().year + 1, 5, 16)))
     }
 
     @Test
     fun `frist for inntektsjekk skal ikke være i juli eller august`() {
-        val frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 8,28))
-        assertThat(frist).isEqualTo((LocalDate.of(LocalDate.now().year + 1, 6, 30)))
+        var frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 7, 28))
+        assertThat(frist).isEqualTo((LocalDate.of(LocalDate.now().year + 1, 5, 28)))
+
+        frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 8, 28))
+        assertThat(frist).isEqualTo((LocalDate.of(LocalDate.now().year + 1, 6, 28)))
     }
 
     @Test
+    fun `frist for inntektsjekt - dersom vedtakstidspunkt er 17 eller 18 august skal tidspunkt fremskyndes to dager i tillegg til 2 måneder`() {
+        var frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 7, 17))
+        assertThat(frist).isEqualTo((LocalDate.of(LocalDate.now().year + 1, 5, 15)))
+
+        frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 7, 18))
+        assertThat(frist).isEqualTo((LocalDate.of(LocalDate.now().year + 1, 5, 16)))
+    }
+
+
+    @Test
     fun `frist for inntektsjekk skal ikke være den 6 dagen i måneden`() {
-        val frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 9,6))
+        val frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 9, 6))
         assertThat(frist).isEqualTo((LocalDate.of(LocalDate.now().year + 1, 9, 5)))
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/oppgave/OppgaveServiceTest.kt
@@ -459,46 +459,6 @@ internal class OppgaveServiceTest {
         assertThat(oppgave.id).isEqualTo(GSAK_OPPGAVE_ID)
     }
 
-    @Test
-    fun `lovlig frist for inntektsjekk skal ikke fremskyndes`() {
-        val frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 9, 1))
-        assertThat(frist).isEqualTo((LocalDate.of(LocalDate.now().year + 1, 9, 1)))
-    }
-
-    @Test
-    fun `frist for inntektsjekk skal ikke være 17 eller 18 mai`() {
-        var frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 5, 17))
-        assertThat(frist).isEqualTo((LocalDate.of(LocalDate.now().year + 1, 5, 15)))
-
-        frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 5, 18))
-        assertThat(frist).isEqualTo((LocalDate.of(LocalDate.now().year + 1, 5, 16)))
-    }
-
-    @Test
-    fun `frist for inntektsjekk skal ikke være i juli eller august`() {
-        var frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 7, 28))
-        assertThat(frist).isEqualTo((LocalDate.of(LocalDate.now().year + 1, 5, 28)))
-
-        frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 8, 28))
-        assertThat(frist).isEqualTo((LocalDate.of(LocalDate.now().year + 1, 6, 28)))
-    }
-
-    @Test
-    fun `frist for inntektsjekt - dersom vedtakstidspunkt er 17 eller 18 august skal tidspunkt fremskyndes to dager i tillegg til 2 måneder`() {
-        var frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 7, 17))
-        assertThat(frist).isEqualTo((LocalDate.of(LocalDate.now().year + 1, 5, 15)))
-
-        frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 7, 18))
-        assertThat(frist).isEqualTo((LocalDate.of(LocalDate.now().year + 1, 5, 16)))
-    }
-
-
-    @Test
-    fun `frist for inntektsjekk skal ikke være den 6 dagen i måneden`() {
-        val frist = oppgaveService.lagFristFerdigstillelseInntektsjekk(LocalDate.of(LocalDate.now().year, 9, 6))
-        assertThat(frist).isEqualTo((LocalDate.of(LocalDate.now().year + 1, 9, 5)))
-    }
-
     private fun lagMigreringsIverksetting() = lagIverksettData(
         UUID.randomUUID(),
         BehandlingType.REVURDERING,

--- a/src/test/resources/no/nav/familie/ef/iverksett/cucumber/fristFerdigstillelseInntektsjekk.feature
+++ b/src/test/resources/no/nav/familie/ef/iverksett/cucumber/fristFerdigstillelseInntektsjekk.feature
@@ -1,0 +1,24 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Ved en førstegangsbehandling kan saksbehandler velge at det automatisk skal opprettes en fremleggsoppgave for sjekk av inntekt 1 år frem i tid.
+
+  Scenariomal: Fremleggsoppgaver skal ikke falle på den 6. i hver måned, 17. og 18. mai, eller i juli eller august
+
+    Gitt følgende vedtaksdato <Vedtaksdato>
+
+    Når lag frist for ferdigstillelse av inntektsjekk
+
+    Så forvent frist satt til <Dato>
+
+    Eksempler:
+      | Vedtaksdato | Dato       | Kommentar                                                                            |
+      | 01.09.2023  | 01.09.2024 | Ett år frem i tid                                                                    |
+      | 21.08.2023  | 21.06.2024 | Skal ikke lande på juli eller august, trekker fra 2 måneder                          |
+      | 01.07.2023  | 01.05.2024 | Skal ikke lande på juli eller august, trekker fra 2 måneder                          |
+      | 17.05.2023  | 15.05.2024 | Skal ikke lande på 17. mai, trekker fra 2 dager                                      |
+      | 18.05.2023  | 16.05.2024 | Skal ikke lande på 18. mai, trekker fra 2 dager                                      |
+      | 06.05.2023  | 07.05.2024 | Skal ikke lande på 6. dagen i en måned, skal legge til en dag                        |
+      | 06.07.2023  | 07.05.2024 | Skal ikke lande på juli/august og den 6., trekker fra 2 måneder og legger til en dag |
+      | 17.07.2023  | 15.05.2024 | Skal ikke lande på juli og den 17/18 mai., trekker fra 2 måneder og to dager         |
+


### PR DESCRIPTION
Ved en førstegangsbehandling kan saksbehandler velge at det automatisk skal opprettes en fremleggsoppgave for sjekk av inntekt 1 år frem i tid. Det er ønskelig at disse fremleggsoppgavene ikke faller på følgende tidspunkter:
- den 6. i hver måned
- 17 og 18. mai 
- alle datoer som faller i juli og august - disse skal ha fremleggsoppgave 10 mnd frem i tid, ikke ett år

Testet i preprod i dag den 22. august, og oppgaven fikk frist 24. juli som følge av helg. Det betyr at det allikevel kan settes frist til 1. juli: https://nav-it.slack.com/archives/C01087QRJ2U/p1692684671155179?thread_ts=1692617931.793899&cid=C01087QRJ2U

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-14442)