### PR TITLE
Patch arbeidsoppfølging - send melding på bruker som mangler

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/PatchArbeidsoppfølgingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/arbeidsoppfolging/PatchArbeidsoppfølgingController.kt
@@ -1,0 +1,28 @@
+package no.nav.familie.ef.iverksett.arbeidsoppfolging
+
+import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
+import no.nav.familie.ef.iverksett.repository.findByIdOrThrow
+import no.nav.security.token.support.core.api.Unprotected
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping(
+    path = ["/api/arbeidsoppfolging"],
+)
+@Unprotected
+class PatchArbeidsoppfølgingController(
+    val iverksettingRepository: IverksettingRepository,
+    val arbeidsoppfølgingService: ArbeidsoppfølgingService,
+) {
+    @GetMapping("/patch/")
+    fun publiserVedtakshendelser(): ResponseEntity<Any> {
+        val behandlingId = UUID.fromString("202cbaed-d92f-406f-b208-7a84d014df65")
+        val iverksettData = iverksettingRepository.findByIdOrThrow(behandlingId).data
+        arbeidsoppfølgingService.sendTilKafka(iverksettData)
+        return ResponseEntity.ok().build()
+    }
+}


### PR DESCRIPTION
Arbeidsoppfølging mangler informasjon om en bruker. Det skal ha vært sendt kafka-melding på denne brukeren, men ikke godt å si hva som har skjedd, da det er så lenge siden at det ikke finnes spor av hva som har skjedd i hverken logger eller tasker i db. Har ikke prøvd å grave mye i hvordan dette kan ha skjedd, men hvis dette er noe som skjer flere ganger så må vi se nærmere på det.


[JIRA](https://jira.adeo.no/browse/FAGSYSTEM-323003)
[Slack-tråd](https://nav-it.slack.com/archives/CJN0STWB0/p1710837923601869)