### PR TITLE
Skal justere frist for fremleggsoppgave sånn at fristen ikke lander p…

### DIFF
--- a/src/test/resources/no/nav/familie/ef/iverksett/cucumber/fristFerdigstillelseInntektsjekk.feature
+++ b/src/test/resources/no/nav/familie/ef/iverksett/cucumber/fristFerdigstillelseInntektsjekk.feature
@@ -3,7 +3,7 @@
 
 Egenskap: Ved en førstegangsbehandling kan saksbehandler velge at det automatisk skal opprettes en fremleggsoppgave for sjekk av inntekt 1 år frem i tid.
 
-  Scenariomal: Fremleggsoppgaver skal ikke falle på den 6. i hver måned, 17. og 18. mai, eller i juli eller august
+  Scenariomal: Fremleggsoppgaver skal ikke falle på den 6. i hver måned, 17. og 18. mai, eller i juli, august, eller september
 
     Gitt følgende vedtaksdato <Vedtaksdato>
 
@@ -13,9 +13,10 @@ Egenskap: Ved en førstegangsbehandling kan saksbehandler velge at det automatis
 
     Eksempler:
       | Vedtaksdato | Dato       | Kommentar                                                                            |
-      | 01.09.2023  | 01.09.2024 | Ett år frem i tid                                                                    |
+      | 01.10.2023  | 01.10.2024 | Ett år frem i tid                                                                    |
       | 21.08.2023  | 21.06.2024 | Skal ikke lande på juli eller august, trekker fra 2 måneder                          |
-      | 01.07.2023  | 01.05.2024 | Skal ikke lande på juli eller august, trekker fra 2 måneder                          |
+      | 31.08.2023  | 28.06.2024 | Skal ikke lande på juli eller august, trekker fra 2 måneder, kompenser for helg      |
+      | 01.09.2023  | 03.06.2024 | Skal ikke lande på juli eller august, trekker fra 2 måneder, kompenser for helg      |
       | 17.05.2023  | 15.05.2024 | Skal ikke lande på 17. mai, trekker fra 2 dager                                      |
       | 18.05.2023  | 16.05.2024 | Skal ikke lande på 18. mai, trekker fra 2 dager                                      |
       | 06.05.2023  | 07.05.2024 | Skal ikke lande på 6. dagen i en måned, skal legge til en dag                        |


### PR DESCRIPTION
…å en helg nærme månedsskifte. Skal også unngå frist i september.

Virker som at oppgavesystemet skyver fristen hvis datoen lander på ei helg, og da kan vi skli inn i neste mnd. Satser på å trekke fra to dager hvis dette skjer. 

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-20663