### PR TITLE
Tilgang til arbeidsoppfølging i gcp

### DIFF
--- a/kafka-aiven/arbeidsoppfølging/topic-arbeidsoppfølging-dev.yaml
+++ b/kafka-aiven/arbeidsoppfølging/topic-arbeidsoppfølging-dev.yaml
@@ -19,5 +19,8 @@ spec:
       application: familie-ef-iverksett
       access: readwrite
     - team: pto
-      application: veilarbportefolje
+      application: veilarbportefolje #ON-PREM
+      access: read
+    - team: obo
+      application: veilarbportefolje #GCP
       access: read


### PR DESCRIPTION
Arbeidsoppfølging skal teste migreringen til GCP i dev og trenger derfor tilgang til kafka topic for app som er i namespace obo som er i gcp.

https://nav-it.slack.com/archives/CJN0STWB0/p1723465038678779