### PR TITLE
Setter db tier til custom-1-3840, da det er anbefalt at det ikke brukes db-f1-micro som er default i prod.

### DIFF
--- a/.deploy/nais-preprod.yaml
+++ b/.deploy/nais-preprod.yaml
@@ -62,6 +62,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_14 # IF This is changed, all data will be lost. Read on nais.io how to upgrade
+        tier: db-f1-micro
         diskAutoresize: true
         cascadingDelete: false
         pointInTimeRecovery: true

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -63,6 +63,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_14 # IF This is changed, all data will be lost. Read on nais.io how to upgrade
+        tier: db-custom-1-3840
         diskAutoresize: true
         cascadingDelete: false
         pointInTimeRecovery: true


### PR DESCRIPTION
Det er nå et krav i nais.yaml-fil inneholder tier ved deploy til prod.