### PR TITLE
Ta i bruk tilbakekreving som er flyttet til nytt nais team i preprod

### DIFF
--- a/.deploy/nais-preprod.yaml
+++ b/.deploy/nais-preprod.yaml
@@ -51,7 +51,8 @@ spec:
         - application: familie-ef-e2e
     outbound:
       rules:
-        - application: familie-tilbake
+        - application: tilbakekreving
+          namespace: tilbake
       external:
         - host: b27apvl219.preprod.local
           ports:

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/TilbakekrevingListener.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/TilbakekrevingListener.kt
@@ -28,7 +28,7 @@ class TilbakekrevingListener(
 
     @KafkaListener(
         id = "familie-ef-iverksett",
-        topics = ["teamfamilie.privat-tbk-hentfagsystemsbehandling-request-topic"],
+        topics = ["\${FAGSYSTEMBEHANDLING_REQUEST_TOPIC}"],
         containerFactory = "concurrentTilbakekrevingListenerContainerFactory",
     )
     fun listen(consumerRecord: ConsumerRecord<String, String>) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,3 +9,9 @@ DEPLOY_ENV: dev
 ENSLIG_FORSORGER_VEDTAK_TOPIC: teamfamilie.aapen-ensligforsorger-vedtak-test
 ENSLIG_FORSORGER_BEHANDLING_TOPIC: teamfamilie.aapen-ensligforsorger-behandling-test
 prosessering.rolle: "928636f4-fd0d-4149-978e-a6fb68bb19de" # 0000-GA-STDAPPS 928636f4-fd0d-4149-978e-a6fb68bb19de
+
+FAMILIE_TILBAKE_URL: http://tilbakekreving.tilbake
+FAMILIE_TILBAKE_SCOPE: api://${DEPLOY_ENV}-gcp.tilbake.tilbakekreving/.default
+TILBAKEKREVING_REQUEST_TOPIC:
+FAGSYSTEMBEHANDLING_REQUEST_TOPIC: tilbake.privat-tbk-hentfagsystemsbehandling
+FAGSYSTEMBEHANDLING_RESPONS_TOPIC: tilbake.privat-tbk-hentfagsystemsbehandling-svar

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -147,6 +147,7 @@ ENSLIG_FORSORGER_VEDTAK_TOPIC: teamfamilie.aapen-ensligforsorger-vedtak-v1
 ENSLIG_FORSORGER_BEHANDLING_TOPIC: teamfamilie.aapen-ensligforsorger-behandling-v1
 ARBEIDSOPPFOLGING_VEDTAK_TOPIC: teamfamilie.aapen-ensligforsorger-vedtak-arbeidsoppfolging
 VEDTAK_TOPIC: teamfamilie.aapen-ensligforsorger-iverksatt-vedtak
+FAGSYSTEMBEHANDLING_REQUEST_TOPIC: teamfamilie.privat-tbk-hentfagsystemsbehandling-request-topic
 FAGSYSTEMBEHANDLING_RESPONS_TOPIC: teamfamilie.privat-tbk-hentfagsystemsbehandling-respons-topic
 KAFKA_TOPIC_DITTNAV: min-side.aapen-brukernotifikasjon-beskjed-v1
 prosessering:


### PR DESCRIPTION
Team Tilbake skal ta over tilbakekrevingsløsningen. Den eksisterende løsningen kjører nå i teamfamilie nais teamet, og for å ta ordentlig eierskap til løsningen og gjøre det til en NAV fellestjeneste ønsker vi å flytte det til et NAIS team som er mer generelt.