### PR TITLE
Feature - brukernotifikasjon topic migrering som bruker intern Kotlin builder, gjemt bak feature flagg

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,11 @@
         <familie.eksterne-kontrakter.arbeidsoppfolging>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.arbeidsoppfolging>
         <prosessering.version>2.20250102104603_293d453</prosessering.version>
         <utbetalingsgenerator.version>1.0_20241125101646_0fefaff</utbetalingsgenerator.version>
+
+        <!--TODO: Trenges jeg mere?-->
         <brukernotifikasjon-schemas.version>2.6.0</brukernotifikasjon-schemas.version>
+
+        <brukervarsel-builder.version>2.1.1</brukervarsel-builder.version>
         <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
         <confluent.version>7.8.0</confluent.version>
         <mockk-jvm.version>1.13.14</mockk-jvm.version>
@@ -218,12 +222,19 @@
             <artifactId>http-client</artifactId>
             <version>${felles.version}</version>
         </dependency>
+
+        <!--TODO: Trenges jeg mere?-->
         <dependency>
             <groupId>no.nav.tms</groupId>
             <artifactId>brukernotifikasjon-schemas</artifactId>
             <version>${brukernotifikasjon-schemas.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>no.nav.tms.varsel</groupId>
+            <artifactId>kotlin-builder</artifactId>
+            <version>${brukervarsel-builder.version}</version>
+        </dependency>
         <dependency>
             <groupId>no.nav.familie.felles</groupId>
             <artifactId>familie-utbetalingsgenerator</artifactId>

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
@@ -24,9 +24,9 @@ import java.util.UUID
 @Service
 class BrukernotifikasjonKafkaProducer(
     @Value("\${KAFKA_TOPIC_DITTNAV}")
-    private val brukerNotifikasjontopic: String,
-    @Value("\${NY_KAFKA_TOPIC_DITTNAV}")
-    private val nyBrukerNotifikasjonTopic: String,
+    private val brukernotifikasjonTopic: String,
+    @Value("\${KAFKA_TOPIC_BRUKERVARSEL}")
+    private val nyBrukernotifikasjonTopic: String,
     @Value("\${NAIS_APP_NAME}")
     val applicationName: String,
     @Value("\${NAIS_NAMESPACE}")
@@ -46,14 +46,14 @@ class BrukernotifikasjonKafkaProducer(
         val nokkel = lagNøkkel(iverksett.søker.personIdent, behandlingId)
         val beskjed = lagBeskjed(iverksett)
 
-        secureLogger.info("Sender til Kafka topic: {}: {}", brukerNotifikasjontopic, beskjed)
+        secureLogger.info("Sender til Kafka topic: {}: {}", brukernotifikasjonTopic, beskjed)
         runCatching {
-            val producerRecord = ProducerRecord(brukerNotifikasjontopic, nokkel, beskjed)
+            val producerRecord = ProducerRecord(brukernotifikasjonTopic, nokkel, beskjed)
             kafkaTemplate.send(producerRecord).get()
         }.onFailure {
-            val errorMessage = "Kunne ikke sende brukernotifikasjon til topic: $brukerNotifikasjontopic. Se secure logs for mer informasjon."
+            val errorMessage = "Kunne ikke sende brukernotifikasjon til topic: $brukernotifikasjonTopic. Se secure logs for mer informasjon."
             logger.error(errorMessage)
-            secureLogger.error("Kunne ikke sende brukernotifikasjon til topic: {}", brukerNotifikasjontopic, it)
+            secureLogger.error("Kunne ikke sende brukernotifikasjon til topic: {}", brukernotifikasjonTopic, it)
             throw RuntimeException(errorMessage)
         }
     }
@@ -88,15 +88,15 @@ class BrukernotifikasjonKafkaProducer(
                     )
             }
 
-        secureLogger.info("Sender til Kafka topic: {}: {}", nyBrukerNotifikasjonTopic, opprettVarsel)
+        secureLogger.info("Sender til Kafka topic: {}: {}", nyBrukernotifikasjonTopic, opprettVarsel)
 
         runCatching {
-            val producerRecord = ProducerRecord(nyBrukerNotifikasjonTopic, generertVarselId, opprettVarsel)
+            val producerRecord = ProducerRecord(nyBrukernotifikasjonTopic, generertVarselId, opprettVarsel)
             migrertKafkaTemplate.send(producerRecord).get()
         }.onFailure {
-            val errorMessage = "Kunne ikke sende brukernotifikasjon til topic: $nyBrukerNotifikasjonTopic. Se secure logs for mer informasjon."
+            val errorMessage = "Kunne ikke sende brukernotifikasjon til topic: $nyBrukernotifikasjonTopic. Se secure logs for mer informasjon."
             logger.error(errorMessage)
-            secureLogger.error("Kunne ikke sende brukernotifikasjon til topic: {}", nyBrukerNotifikasjonTopic, it)
+            secureLogger.error("Kunne ikke sende brukernotifikasjon til topic: {}", nyBrukernotifikasjonTopic, it)
 
             throw RuntimeException(errorMessage)
         }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
@@ -15,10 +15,16 @@ import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.UUID
+import no.nav.tms.varsel.action.Produsent
+import no.nav.tms.varsel.action.Sensitivitet
+import no.nav.tms.varsel.action.Tekst
+import no.nav.tms.varsel.action.Varseltype
+import no.nav.tms.varsel.builder.VarselActionBuilder
 
 @Service
 class BrukernotifikasjonKafkaProducer(
     private val kafkaTemplate: KafkaTemplate<NokkelInput, BeskjedInput>,
+    private val migrertKafkaTemplate: KafkaTemplate<String, String>,
 ) {
     @Value("\${KAFKA_TOPIC_DITTNAV}")
     private lateinit var topic: String
@@ -45,6 +51,47 @@ class BrukernotifikasjonKafkaProducer(
         }
     }
 
+    fun sendBeskjedTilBrukerMedBuilder(
+        personIdent: String,
+        iverksettOvergangsstønad: IverksettOvergangsstønad,
+        behandlingId: UUID
+    ) {
+        val generertVarselId = behandlingId.toString()
+
+        val opprettVarsel = VarselActionBuilder.opprett {
+            type = Varseltype.Beskjed
+            varselId = generertVarselId
+            sensitivitet = Sensitivitet.High
+            ident = personIdent
+            aktivFremTil = null
+
+            tekst = Tekst(
+                spraakkode = "nb",
+                tekst = lagMelding(iverksettOvergangsstønad),
+                default = true,
+            )
+
+            produsent = Produsent(
+                cluster = APPLICATION_CLUSTER,
+                namespace = APPLICATION_NAMESPACE,
+                appnavn = APPLICATION_NAME,
+            )
+        }
+
+        secureLogger.info("Sender til Kafka topic: {}: {}", topic, opprettVarsel)
+
+        runCatching {
+            val producerRecord = ProducerRecord(topic, generertVarselId, opprettVarsel)
+            migrertKafkaTemplate.send(producerRecord).get()
+        }.onFailure {
+            val errorMessage = "Kunne ikke sende brukernotifikasjon til topic: $topic. Se secure logs for mer informasjon."
+            logger.error(errorMessage)
+            secureLogger.error("Kunne ikke sende brukernotifikasjon til topic: {}", topic, it)
+
+            throw RuntimeException(errorMessage)
+        }
+    }
+
     private fun lagNøkkel(
         fnr: String,
         behandlingId: UUID,
@@ -67,11 +114,18 @@ class BrukernotifikasjonKafkaProducer(
 
         return builder.build()
     }
-}
 
-fun lagMelding(iverksett: IverksettOvergangsstønad): String =
-    iverksett.vedtak.grunnbeløp?.let {
-        """Fra ${it.periode.fomDato.norskFormat()} har folketrygdens grunnbeløp økt til ${it.grunnbeløp} kroner og overgangsstønaden din er derfor endret. Se nav.no/minside for detaljer.""".trimIndent()
-    } ?: throw IllegalStateException("Mangler grunnbeløp")
+    fun lagMelding(iverksett: IverksettOvergangsstønad): String =
+        iverksett.vedtak.grunnbeløp?.let {
+            """Fra ${it.periode.fomDato.norskFormat()} har folketrygdens grunnbeløp økt til ${it.grunnbeløp} kroner og overgangsstønaden din er derfor endret. Se nav.no/minside for detaljer.""".trimIndent()
+        } ?: throw IllegalStateException("Mangler grunnbeløp")
+
+    companion object {
+        // TODO: Disse burde kanskje ligge i Application.yml filene, men lar de være her inntil videre.
+        const val APPLICATION_NAME = "familie-ef-iverksett"
+        const val APPLICATION_NAMESPACE = "teamfamilie"
+        const val APPLICATION_CLUSTER = "local"
+    }
+}
 
 private fun LocalDate.norskFormat() = this.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
@@ -27,6 +27,12 @@ class BrukernotifikasjonKafkaProducer(
     private val brukerNotifikasjontopic: String,
     @Value("\${NY_KAFKA_TOPIC_DITTNAV}")
     private val nyBrukerNotifikasjonTopic: String,
+    @Value("\${NAIS_APP_NAME}")
+    val applicationName: String,
+    @Value("\${NAIS_NAMESPACE}")
+    val namespace: String,
+    @Value("\${NAIS_CLUSTER_NAME}")
+    val cluster: String,
     private val kafkaTemplate: KafkaTemplate<NokkelInput, BeskjedInput>,
     private val migrertKafkaTemplate: KafkaTemplate<String, String>,
 ) {
@@ -76,9 +82,9 @@ class BrukernotifikasjonKafkaProducer(
 
                 produsent =
                     Produsent(
-                        cluster = APPLICATION_CLUSTER,
-                        namespace = APPLICATION_NAMESPACE,
-                        appnavn = APPLICATION_NAME,
+                        cluster = cluster,
+                        namespace = namespace,
+                        appnavn = applicationName,
                     )
             }
 
@@ -123,13 +129,6 @@ class BrukernotifikasjonKafkaProducer(
         iverksett.vedtak.grunnbeløp?.let {
             """Fra ${it.periode.fomDato.norskFormat()} har folketrygdens grunnbeløp økt til ${it.grunnbeløp} kroner og overgangsstønaden din er derfor endret. Se nav.no/minside for detaljer.""".trimIndent()
         } ?: throw IllegalStateException("Mangler grunnbeløp")
-
-    companion object {
-        // TODO: Disse burde kanskje ligge i Application.yml filene, men lar de være her inntil videre.
-        const val APPLICATION_NAME = "familie-ef-iverksett"
-        const val APPLICATION_NAMESPACE = "teamfamilie"
-        const val APPLICATION_CLUSTER = "local"
-    }
 }
 
 private fun LocalDate.norskFormat() = this.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
@@ -5,6 +5,11 @@ import no.nav.brukernotifikasjon.schemas.builders.NokkelInputBuilder
 import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
 import no.nav.brukernotifikasjon.schemas.input.NokkelInput
 import no.nav.familie.ef.iverksett.iverksetting.domene.IverksettOvergangsstønad
+import no.nav.tms.varsel.action.Produsent
+import no.nav.tms.varsel.action.Sensitivitet
+import no.nav.tms.varsel.action.Tekst
+import no.nav.tms.varsel.action.Varseltype
+import no.nav.tms.varsel.builder.VarselActionBuilder
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -15,11 +20,6 @@ import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.UUID
-import no.nav.tms.varsel.action.Produsent
-import no.nav.tms.varsel.action.Sensitivitet
-import no.nav.tms.varsel.action.Tekst
-import no.nav.tms.varsel.action.Varseltype
-import no.nav.tms.varsel.builder.VarselActionBuilder
 
 @Service
 class BrukernotifikasjonKafkaProducer(
@@ -51,32 +51,35 @@ class BrukernotifikasjonKafkaProducer(
         }
     }
 
-    fun sendBeskjedTilBrukerMedBuilder(
+    fun sendBeskjedTilBrukerMedKafkaBuilder(
         personIdent: String,
         iverksettOvergangsstønad: IverksettOvergangsstønad,
-        behandlingId: UUID
+        behandlingId: UUID,
     ) {
         val generertVarselId = behandlingId.toString()
 
-        val opprettVarsel = VarselActionBuilder.opprett {
-            type = Varseltype.Beskjed
-            varselId = generertVarselId
-            sensitivitet = Sensitivitet.High
-            ident = personIdent
-            aktivFremTil = null
+        val opprettVarsel =
+            VarselActionBuilder.opprett {
+                type = Varseltype.Beskjed
+                varselId = generertVarselId
+                sensitivitet = Sensitivitet.High
+                ident = personIdent
+                aktivFremTil = null
 
-            tekst = Tekst(
-                spraakkode = "nb",
-                tekst = lagMelding(iverksettOvergangsstønad),
-                default = true,
-            )
+                tekst =
+                    Tekst(
+                        spraakkode = "nb",
+                        tekst = lagMelding(iverksettOvergangsstønad),
+                        default = true,
+                    )
 
-            produsent = Produsent(
-                cluster = APPLICATION_CLUSTER,
-                namespace = APPLICATION_NAMESPACE,
-                appnavn = APPLICATION_NAME,
-            )
-        }
+                produsent =
+                    Produsent(
+                        cluster = APPLICATION_CLUSTER,
+                        namespace = APPLICATION_NAMESPACE,
+                        appnavn = APPLICATION_NAME,
+                    )
+            }
 
         secureLogger.info("Sender til Kafka topic: {}: {}", topic, opprettVarsel)
 

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTask.kt
@@ -31,7 +31,7 @@ class SendBrukernotifikasjonVedGOmregningTask(
         // Dobbeltsjekk: Tasken skal egentlig ikke være lagd hvis det ikke er G-omregning
         if (iverksett is IverksettOvergangsstønad && iverksett.erGOmregning()) {
             if (featureToggleService.isEnabled("familie.ef.iverksett.brukernotifikasjon-med-kotlin-builder")) {
-                brukernotifikasjonKafkaProducer.sendBeskjedTilBrukerMedKafkaBuilder(
+                brukernotifikasjonKafkaProducer.sendBeskjedTilBrukerMedKotlinBuilder(
                     personIdent = iverksett.søker.personIdent,
                     iverksettOvergangsstønad = iverksett,
                     behandlingId = behandlingId,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -148,7 +148,7 @@ ENSLIG_FORSORGER_BEHANDLING_TOPIC: teamfamilie.aapen-ensligforsorger-behandling-
 ARBEIDSOPPFOLGING_VEDTAK_TOPIC: teamfamilie.aapen-ensligforsorger-vedtak-arbeidsoppfolging
 VEDTAK_TOPIC: teamfamilie.aapen-ensligforsorger-iverksatt-vedtak
 FAGSYSTEMBEHANDLING_RESPONS_TOPIC: teamfamilie.privat-tbk-hentfagsystemsbehandling-respons-topic
-KAFKA_TOPIC_DITTNAV: min-side.aapen-brukernotifikasjon-beskjed-v1
+KAFKA_TOPIC_DITTNAV: min-side.aapen-brukervarsel-v1
 prosessering:
   continuousRunning.enabled: true
   fixedDelayString:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -149,7 +149,9 @@ ARBEIDSOPPFOLGING_VEDTAK_TOPIC: teamfamilie.aapen-ensligforsorger-vedtak-arbeids
 VEDTAK_TOPIC: teamfamilie.aapen-ensligforsorger-iverksatt-vedtak
 FAGSYSTEMBEHANDLING_REQUEST_TOPIC: teamfamilie.privat-tbk-hentfagsystemsbehandling-request-topic
 FAGSYSTEMBEHANDLING_RESPONS_TOPIC: teamfamilie.privat-tbk-hentfagsystemsbehandling-respons-topic
-KAFKA_TOPIC_DITTNAV: min-side.aapen-brukervarsel-v1
+KAFKA_TOPIC_DITTNAV: min-side.aapen-brukernotifikasjon-beskjed-v1
+NY_KAFKA_TOPIC_DITTNAV: min-side.aapen-brukervarsel-v1
+
 prosessering:
   continuousRunning.enabled: true
   fixedDelayString:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -150,7 +150,7 @@ VEDTAK_TOPIC: teamfamilie.aapen-ensligforsorger-iverksatt-vedtak
 FAGSYSTEMBEHANDLING_REQUEST_TOPIC: teamfamilie.privat-tbk-hentfagsystemsbehandling-request-topic
 FAGSYSTEMBEHANDLING_RESPONS_TOPIC: teamfamilie.privat-tbk-hentfagsystemsbehandling-respons-topic
 KAFKA_TOPIC_DITTNAV: min-side.aapen-brukernotifikasjon-beskjed-v1
-NY_KAFKA_TOPIC_DITTNAV: min-side.aapen-brukervarsel-v1
+KAFKA_TOPIC_BRUKERVARSEL: min-side.aapen-brukervarsel-v1
 
 prosessering:
   continuousRunning.enabled: true

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
@@ -31,6 +31,8 @@ class BrukernotifikasjonKafkaProducerTest {
         BrukernotifikasjonKafkaProducer(
             kafkaTemplate = kafkaTemplate,
             migrertKafkaTemplate = migrertKafkaTemplate,
+            brukerNotifikasjontopic = "brukerNotifikasjontopic",
+            nyBrukerNotifikasjonTopic = "nyBrukerNotifikasjonTopic",
         )
 
     @Nested

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.iverksett.brukernotifikasjon
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.mockk.mockk
 import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
 import no.nav.brukernotifikasjon.schemas.input.NokkelInput
@@ -8,18 +9,31 @@ import no.nav.familie.kontrakter.ef.felles.BehandlingType
 import no.nav.familie.kontrakter.ef.felles.Vedtaksresultat
 import no.nav.familie.kontrakter.ef.iverksett.Grunnbeløp
 import no.nav.familie.kontrakter.felles.Månedsperiode
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.tms.varsel.action.Produsent
+import no.nav.tms.varsel.action.Sensitivitet
+import no.nav.tms.varsel.action.Tekst
+import no.nav.tms.varsel.action.Varseltype
+import no.nav.tms.varsel.builder.VarselActionBuilder
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.kafka.core.KafkaTemplate
 import java.time.LocalDate
 import java.time.YearMonth
+import java.util.UUID
 
 class BrukernotifikasjonKafkaProducerTest {
     private val kafkaTemplate = mockk<KafkaTemplate<NokkelInput, BeskjedInput>>()
-    private val brukernotifikasjonKafkaProducer = BrukernotifikasjonKafkaProducer(kafkaTemplate)
+    private val migrertKafkaTemplate: KafkaTemplate<String, String> = mockk()
 
-    @Test
-    fun `lagBeskjed genererer riktig melding`() {
+    private val brukernotifikasjonKafkaProducer = BrukernotifikasjonKafkaProducer(
+        kafkaTemplate = kafkaTemplate,
+        migrertKafkaTemplate = migrertKafkaTemplate,
+    )
+
+    @Nested
+    inner class GenererNotifikasjonMelding {
         val forventetGOmregningTekst = "Fra 01.05.2023 har folketrygdens grunnbeløp økt til 118620 kroner og overgangsstønaden din er derfor endret. Se nav.no/minside for detaljer."
         val iverksettRevurderingInnvilget =
             lagIverksettData(
@@ -36,9 +50,49 @@ class BrukernotifikasjonKafkaProducerTest {
                         grunnbeløp = 118_620.toBigDecimal(),
                     ),
             )
-        Assertions
-            .assertThat(
-                brukernotifikasjonKafkaProducer.lagBeskjed(iverksettRevurderingInnvilget).getTekst(),
-            ).isEqualTo(forventetGOmregningTekst)
+
+        @Test
+        fun `lagBeskjed genererer riktig melding`() {
+            Assertions
+                .assertThat(
+                    brukernotifikasjonKafkaProducer.lagBeskjed(iverksettRevurderingInnvilget).tekst,
+                ).isEqualTo(forventetGOmregningTekst)
+        }
+
+        @Test
+        fun `lagBeskjed genererer riktig melding med ny builder komponent`() {
+            val opprettVarselJson = VarselActionBuilder.opprett {
+                type = Varseltype.Beskjed
+                varselId = UUID.randomUUID().toString()
+                sensitivitet = Sensitivitet.High
+                ident = "12345678910"
+                aktivFremTil = null
+
+                tekst = Tekst(
+                    spraakkode = "nb",
+                    tekst = brukernotifikasjonKafkaProducer.lagMelding(iverksettRevurderingInnvilget),
+                    default = true,
+                )
+
+                produsent = Produsent(
+                    cluster = "test-cluster",
+                    namespace = "test-namespace",
+                    appnavn = "test-app",
+                )
+            }
+
+            val opprettVarsel: Map<String, Any> = objectMapper.readValue(opprettVarselJson)
+            val tekster = opprettVarsel["tekster"]
+            if (tekster is List<*>) {
+                val tekstMap = tekster.firstOrNull() as? Map<*, *>
+                val tekst = tekstMap?.get("tekst") as? String
+
+                Assertions
+                    .assertThat(tekst)
+                    .isEqualTo(forventetGOmregningTekst)
+            } else {
+                Assertions.fail("Tekster feltet er ikke en liste.")
+            }
+        }
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
@@ -27,10 +27,11 @@ class BrukernotifikasjonKafkaProducerTest {
     private val kafkaTemplate = mockk<KafkaTemplate<NokkelInput, BeskjedInput>>()
     private val migrertKafkaTemplate: KafkaTemplate<String, String> = mockk()
 
-    private val brukernotifikasjonKafkaProducer = BrukernotifikasjonKafkaProducer(
-        kafkaTemplate = kafkaTemplate,
-        migrertKafkaTemplate = migrertKafkaTemplate,
-    )
+    private val brukernotifikasjonKafkaProducer =
+        BrukernotifikasjonKafkaProducer(
+            kafkaTemplate = kafkaTemplate,
+            migrertKafkaTemplate = migrertKafkaTemplate,
+        )
 
     @Nested
     inner class GenererNotifikasjonMelding {
@@ -61,25 +62,28 @@ class BrukernotifikasjonKafkaProducerTest {
 
         @Test
         fun `lagBeskjed genererer riktig melding med ny builder komponent`() {
-            val opprettVarselJson = VarselActionBuilder.opprett {
-                type = Varseltype.Beskjed
-                varselId = UUID.randomUUID().toString()
-                sensitivitet = Sensitivitet.High
-                ident = "12345678910"
-                aktivFremTil = null
+            val opprettVarselJson =
+                VarselActionBuilder.opprett {
+                    type = Varseltype.Beskjed
+                    varselId = UUID.randomUUID().toString()
+                    sensitivitet = Sensitivitet.High
+                    ident = "12345678910"
+                    aktivFremTil = null
 
-                tekst = Tekst(
-                    spraakkode = "nb",
-                    tekst = brukernotifikasjonKafkaProducer.lagMelding(iverksettRevurderingInnvilget),
-                    default = true,
-                )
+                    tekst =
+                        Tekst(
+                            spraakkode = "nb",
+                            tekst = brukernotifikasjonKafkaProducer.lagMelding(iverksettRevurderingInnvilget),
+                            default = true,
+                        )
 
-                produsent = Produsent(
-                    cluster = "test-cluster",
-                    namespace = "test-namespace",
-                    appnavn = "test-app",
-                )
-            }
+                    produsent =
+                        Produsent(
+                            cluster = "test-cluster",
+                            namespace = "test-namespace",
+                            appnavn = "test-app",
+                        )
+                }
 
             val opprettVarsel: Map<String, Any> = objectMapper.readValue(opprettVarselJson)
             val tekster = opprettVarsel["tekster"]

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
@@ -29,10 +29,13 @@ class BrukernotifikasjonKafkaProducerTest {
 
     private val brukernotifikasjonKafkaProducer =
         BrukernotifikasjonKafkaProducer(
-            kafkaTemplate = kafkaTemplate,
-            migrertKafkaTemplate = migrertKafkaTemplate,
             brukerNotifikasjontopic = "brukerNotifikasjontopic",
             nyBrukerNotifikasjonTopic = "nyBrukerNotifikasjonTopic",
+            applicationName = "test-app",
+            namespace = "test-namespace",
+            cluster = "test-cluster",
+            kafkaTemplate = kafkaTemplate,
+            migrertKafkaTemplate = migrertKafkaTemplate,
         )
 
     @Nested

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
@@ -29,8 +29,8 @@ class BrukernotifikasjonKafkaProducerTest {
 
     private val brukernotifikasjonKafkaProducer =
         BrukernotifikasjonKafkaProducer(
-            brukerNotifikasjontopic = "brukerNotifikasjontopic",
-            nyBrukerNotifikasjonTopic = "nyBrukerNotifikasjonTopic",
+            brukernotifikasjonTopic = "brukerNotifikasjontopic",
+            nyBrukernotifikasjonTopic = "nyBrukerNotifikasjonTopic",
             applicationName = "test-app",
             namespace = "test-namespace",
             cluster = "test-cluster",

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTaskTest.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ef.iverksett.infrastruktur.transformer.toDomain
 import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
 import no.nav.familie.ef.iverksett.lagIverksett
 import no.nav.familie.ef.iverksett.repository.findByIdOrThrow
+import no.nav.familie.ef.iverksett.util.mockFeatureToggleService
 import no.nav.familie.ef.iverksett.util.opprettIverksettDto
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.prosessering.domene.Task
@@ -21,7 +22,14 @@ class SendBrukernotifikasjonVedGOmregningTaskTest {
     private val iverksettingRepository = mockk<IverksettingRepository>()
     private val brukernotifikasjonKafkaProducer = mockk<BrukernotifikasjonKafkaProducer>()
     private val taskService = mockk<TaskService>()
-    private val task = SendBrukernotifikasjonVedGOmregningTask(brukernotifikasjonKafkaProducer, iverksettingRepository, taskService)
+    private val featureToggleService = mockFeatureToggleService()
+    private val task =
+        SendBrukernotifikasjonVedGOmregningTask(
+            brukernotifikasjonKafkaProducer = brukernotifikasjonKafkaProducer,
+            iverksettingRepository = iverksettingRepository,
+            taskService = taskService,
+            featureToggleService = featureToggleService,
+        )
 
     @BeforeEach
     internal fun setUp() {

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -28,7 +28,9 @@ arena-mq:
   servicebrukerPassord: srvuserPassword
 
 unleash:
-  enabled: true
+  enabled: false
+UNLEASH_SERVER_API_URL: http://localhost:98765
+UNLEASH_SERVER_API_TOKEN: tulletoken-ikke-i-bruk
 
 FAMILIE_OPPDRAG_API_URL: https://familie-oppdrag.dev.intern.nav.no
 AZURE_OPENID_CONFIG_TOKEN_ENDPOINT: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/token
@@ -43,5 +45,9 @@ KAFKA_BROKERS: hostname:1234
 KAFKA_KEYSTORE_PATH: kafkaKeystorePath
 KAFKA_CREDSTORE_PASSWORD: kafkaCredstorePassword
 KAFKA_TRUSTSTORE_PATH: kafkaTruststorePath
+KAFKA_SCHEMA_REGISTRY: kafkaSchemaRegistry
+KAFKA_SCHEMA_REGISTRY_USER: kafkaSchemaRegistryUser
+KAFKA_SCHEMA_REGISTRY_PASSWORD: kafkaSchemaRegistryPassword
+
 
 prosessering.rolle: "928636f4-fd0d-4149-978e-a6fb68bb19de" # 0000-GA-STDAPPS 928636f4-fd0d-4149-978e-a6fb68bb19de

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -34,6 +34,9 @@ FAMILIE_OPPDRAG_API_URL: https://familie-oppdrag.dev.intern.nav.no
 AZURE_OPENID_CONFIG_TOKEN_ENDPOINT: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/token
 FAMILIE_INTEGRASJONER_API_URL: http://localhost:9085
 FAMILIE_TILBAKE_URL: http://localhost:8030
+
+NAIS_APP_NAME: familie-ef-iverksett
+NAIS_NAMESPACE: teamfamilie
 NAIS_CLUSTER_NAME: dev
 
 KAFKA_BROKERS: hostname:1234

--- a/src/test/resources/application-servertest.yml
+++ b/src/test/resources/application-servertest.yml
@@ -31,7 +31,7 @@ arena-mq:
   servicebrukerPassord: srvuserPassword
 
 unleash:
-  enabled: true
+  enabled: false
 
 FAMILIE_OPPDRAG_API_URL: http://localhost:8087
 FAMILIE_INTEGRASJONER_API_URL: http://localhost:9085
@@ -53,3 +53,4 @@ KAFKA_SCHEMA_REGISTRY_PASSWORD: kafkaSchemaRegistryPassword
 UNLEASH_SERVER_API_URL: http://localhost:4242/api
 UNLEASH_SERVER_API_TOKEN: token
 NAIS_APP_NAME: familie-ef-iverksett
+NAIS_NAMESPACE: teamfamilie


### PR DESCRIPTION
# Feature - brukernotifikasjon topic migrering som bruker intern Kotlin builder, gjemt bak feature flagg

Hvorfor er denne endringen nødvendig? ✨

Denne PRen prøver å håndtere den nye måten å produsere varsler (brukernotifikasjon) siden vi nå migrer vekk fra Avro, til ny intern Kotlin builder. Notifikasjonen det gjelder er `brukernotifikasjon`. Den nye metoden er gjemt bak feature flagget `familie.ef.iverksett.brukernotifikasjon-med-kotlin-builder` slik at vi kan ta det i bruk når endringen eventuelt gjelder. På denne måten er vi bakoverkompatibel for en liten stund. 

Oppgave kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-23711).

## Verdt å nevne

* Jeg har faktisk ikke testet løsningen (vet ikke om det fungerer). Dette tror jeg @olekvernberg må gjøre.
* Skrev en enkel test som er litt "hacky" siden vi når serializerer og bruker JSON.