### PR TITLE
Brukernotifikasjon implementasjon med migerering er nå åpen for alle, samt små endringer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,10 +24,6 @@
         <familie.eksterne-kontrakter.arbeidsoppfolging>2.0_20230214104704_706e9c0</familie.eksterne-kontrakter.arbeidsoppfolging>
         <prosessering.version>2.20250102104603_293d453</prosessering.version>
         <utbetalingsgenerator.version>1.0_20241125101646_0fefaff</utbetalingsgenerator.version>
-
-        <!--TODO: Trenges jeg mere?-->
-        <brukernotifikasjon-schemas.version>2.6.0</brukernotifikasjon-schemas.version>
-
         <brukervarsel-builder.version>2.1.1</brukervarsel-builder.version>
         <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
         <confluent.version>7.8.0</confluent.version>
@@ -222,14 +218,6 @@
             <artifactId>http-client</artifactId>
             <version>${felles.version}</version>
         </dependency>
-
-        <!--TODO: Trenges jeg mere?-->
-        <dependency>
-            <groupId>no.nav.tms</groupId>
-            <artifactId>brukernotifikasjon-schemas</artifactId>
-            <version>${brukernotifikasjon-schemas.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>no.nav.tms.varsel</groupId>
             <artifactId>kotlin-builder</artifactId>

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
@@ -1,9 +1,5 @@
 package no.nav.familie.ef.iverksett.brukernotifikasjon
 
-import no.nav.brukernotifikasjon.schemas.builders.BeskjedInputBuilder
-import no.nav.brukernotifikasjon.schemas.builders.NokkelInputBuilder
-import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
-import no.nav.brukernotifikasjon.schemas.input.NokkelInput
 import no.nav.familie.ef.iverksett.iverksetting.domene.IverksettOvergangsstønad
 import no.nav.tms.varsel.action.Produsent
 import no.nav.tms.varsel.action.Sensitivitet
@@ -16,52 +12,29 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Service
 import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 @Service
 class BrukernotifikasjonKafkaProducer(
-    @Value("\${KAFKA_TOPIC_DITTNAV}")
-    private val brukernotifikasjonTopic: String,
-    @Value("\${KAFKA_TOPIC_BRUKERVARSEL}")
-    private val nyBrukernotifikasjonTopic: String,
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+    @Value("\${BRUKERNOTIFIKASJON_BESKJED_TOPIC}")
+    private val topic: String,
     @Value("\${NAIS_APP_NAME}")
     val applicationName: String,
     @Value("\${NAIS_NAMESPACE}")
     val namespace: String,
     @Value("\${NAIS_CLUSTER_NAME}")
     val cluster: String,
-    private val kafkaTemplate: KafkaTemplate<NokkelInput, BeskjedInput>,
-    private val migrertKafkaTemplate: KafkaTemplate<String, String>,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
     fun sendBeskjedTilBruker(
-        iverksett: IverksettOvergangsstønad,
-        behandlingId: UUID,
-    ) {
-        val nokkel = lagNøkkel(iverksett.søker.personIdent, behandlingId)
-        val beskjed = lagBeskjed(iverksett)
-
-        secureLogger.info("Sender til Kafka topic: {}: {}", brukernotifikasjonTopic, beskjed)
-        runCatching {
-            val producerRecord = ProducerRecord(brukernotifikasjonTopic, nokkel, beskjed)
-            kafkaTemplate.send(producerRecord).get()
-        }.onFailure {
-            val errorMessage = "Kunne ikke sende brukernotifikasjon til topic: $brukernotifikasjonTopic. Se secure logs for mer informasjon."
-            logger.error(errorMessage)
-            secureLogger.error("Kunne ikke sende brukernotifikasjon til topic: {}", brukernotifikasjonTopic, it)
-            throw RuntimeException(errorMessage)
-        }
-    }
-
-    fun sendBeskjedTilBrukerMedKotlinBuilder(
         personIdent: String,
         iverksettOvergangsstønad: IverksettOvergangsstønad,
         behandlingId: UUID,
+        melding: String,
     ) {
         val generertVarselId = behandlingId.toString()
 
@@ -76,7 +49,7 @@ class BrukernotifikasjonKafkaProducer(
                 tekst =
                     Tekst(
                         spraakkode = "nb",
-                        tekst = lagMelding(iverksettOvergangsstønad),
+                        tekst = melding,
                         default = true,
                     )
 
@@ -88,41 +61,18 @@ class BrukernotifikasjonKafkaProducer(
                     )
             }
 
-        secureLogger.info("Sender til Kafka topic: {}: {}", nyBrukernotifikasjonTopic, opprettVarsel)
+        secureLogger.info("Sender til Kafka topic: {}: {}", topic, opprettVarsel)
 
         runCatching {
-            val producerRecord = ProducerRecord(nyBrukernotifikasjonTopic, generertVarselId, opprettVarsel)
-            migrertKafkaTemplate.send(producerRecord).get()
+            val producerRecord = ProducerRecord(topic, generertVarselId, opprettVarsel)
+            kafkaTemplate.send(producerRecord).get()
         }.onFailure {
-            val errorMessage = "Kunne ikke sende brukernotifikasjon til topic: $nyBrukernotifikasjonTopic. Se secure logs for mer informasjon."
+            val errorMessage = "Kunne ikke sende brukernotifikasjon til topic: $topic. Se secure logs for mer informasjon."
             logger.error(errorMessage)
-            secureLogger.error("Kunne ikke sende brukernotifikasjon til topic: {}", nyBrukernotifikasjonTopic, it)
+            secureLogger.error("Kunne ikke sende brukernotifikasjon til topic: {}", topic, it)
 
             throw RuntimeException(errorMessage)
         }
-    }
-
-    private fun lagNøkkel(
-        fnr: String,
-        behandlingId: UUID,
-    ): NokkelInput =
-        NokkelInputBuilder()
-            .withAppnavn("familie-ef-iverksett")
-            .withNamespace("teamfamilie")
-            .withFodselsnummer(fnr)
-            .withGrupperingsId(UUID.randomUUID().toString()) // Setter random UUID uten å lagre fordi feltet skal fjernes
-            .withEventId(behandlingId.toString())
-            .build()
-
-    fun lagBeskjed(iverksett: IverksettOvergangsstønad): BeskjedInput {
-        val builder =
-            BeskjedInputBuilder()
-                .withSikkerhetsnivaa(4)
-                .withSynligFremTil(null)
-                .withTekst(lagMelding(iverksett))
-                .withTidspunkt(LocalDateTime.now(ZoneOffset.UTC))
-
-        return builder.build()
     }
 
     fun lagMelding(iverksett: IverksettOvergangsstønad): String =

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
@@ -18,7 +18,7 @@ import java.util.UUID
 @Service
 class BrukernotifikasjonKafkaProducer(
     private val kafkaTemplate: KafkaTemplate<String, String>,
-    @Value("\${BRUKERNOTIFIKASJON_BESKJED_TOPIC}")
+    @Value("\${BRUKERNOTIFIKASJON_VARSEL_TOPIC}")
     private val topic: String,
     @Value("\${NAIS_APP_NAME}")
     val applicationName: String,

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/configuration/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/configuration/KafkaConfig.kt
@@ -1,11 +1,5 @@
 package no.nav.familie.ef.iverksett.infrastruktur.configuration
 
-import io.confluent.kafka.serializers.KafkaAvroSerializer
-import io.confluent.kafka.serializers.KafkaAvroSerializerConfig
-import no.nav.brukernotifikasjon.schemas.input.BeskjedInput
-import no.nav.brukernotifikasjon.schemas.input.NokkelInput
-import org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG
-import org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties
@@ -37,29 +31,6 @@ class KafkaConfig {
         val producerFactory = DefaultKafkaProducerFactory<String, String>(properties.buildProducerProperties(sslBundles.getIfAvailable()))
 
         return KafkaTemplate(producerFactory).apply<KafkaTemplate<String, String>> {
-            setProducerListener(producerListener)
-        }
-    }
-
-    @Bean
-    fun kafkaTemplateBrukerNotifikasjoner(
-        properties: KafkaProperties,
-        sslBundles: ObjectProvider<SslBundles>,
-    ): KafkaTemplate<NokkelInput, BeskjedInput> {
-        val producerListener = LoggingProducerListener<NokkelInput, BeskjedInput>()
-        producerListener.setIncludeContents(false)
-        val producerFactory =
-            DefaultKafkaProducerFactory<NokkelInput, BeskjedInput>(
-                properties.buildProducerProperties(sslBundles.getIfAvailable()).apply {
-                    put(KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer::class.java)
-                    put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer::class.java)
-                    put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl)
-                    put(KafkaAvroSerializerConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO")
-                    put(KafkaAvroSerializerConfig.USER_INFO_CONFIG, "$schemaRegistryUser:$schemaRegistryPassword")
-                },
-            )
-
-        return KafkaTemplate(producerFactory).apply<KafkaTemplate<NokkelInput, BeskjedInput>> {
             setProducerListener(producerListener)
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -149,8 +149,7 @@ ARBEIDSOPPFOLGING_VEDTAK_TOPIC: teamfamilie.aapen-ensligforsorger-vedtak-arbeids
 VEDTAK_TOPIC: teamfamilie.aapen-ensligforsorger-iverksatt-vedtak
 FAGSYSTEMBEHANDLING_REQUEST_TOPIC: teamfamilie.privat-tbk-hentfagsystemsbehandling-request-topic
 FAGSYSTEMBEHANDLING_RESPONS_TOPIC: teamfamilie.privat-tbk-hentfagsystemsbehandling-respons-topic
-KAFKA_TOPIC_DITTNAV: min-side.aapen-brukernotifikasjon-beskjed-v1
-KAFKA_TOPIC_BRUKERVARSEL: min-side.aapen-brukervarsel-v1
+BRUKERNOTIFIKASJON_BESKJED_TOPIC: min-side.aapen-brukernotifikasjon-beskjed-v1
 
 prosessering:
   continuousRunning.enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -149,7 +149,7 @@ ARBEIDSOPPFOLGING_VEDTAK_TOPIC: teamfamilie.aapen-ensligforsorger-vedtak-arbeids
 VEDTAK_TOPIC: teamfamilie.aapen-ensligforsorger-iverksatt-vedtak
 FAGSYSTEMBEHANDLING_REQUEST_TOPIC: teamfamilie.privat-tbk-hentfagsystemsbehandling-request-topic
 FAGSYSTEMBEHANDLING_RESPONS_TOPIC: teamfamilie.privat-tbk-hentfagsystemsbehandling-respons-topic
-BRUKERNOTIFIKASJON_BESKJED_TOPIC: min-side.aapen-brukernotifikasjon-beskjed-v1
+BRUKERNOTIFIKASJON_VARSEL_TOPIC: min-side.aapen-brukervarsel-v1
 
 prosessering:
   continuousRunning.enabled: true

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/SendBrukernotifikasjonVedGOmregningTaskTest.kt
@@ -9,7 +9,6 @@ import no.nav.familie.ef.iverksett.infrastruktur.transformer.toDomain
 import no.nav.familie.ef.iverksett.iverksetting.IverksettingRepository
 import no.nav.familie.ef.iverksett.lagIverksett
 import no.nav.familie.ef.iverksett.repository.findByIdOrThrow
-import no.nav.familie.ef.iverksett.util.mockFeatureToggleService
 import no.nav.familie.ef.iverksett.util.opprettIverksettDto
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.prosessering.domene.Task
@@ -23,13 +22,11 @@ class SendBrukernotifikasjonVedGOmregningTaskTest {
     private val iverksettingRepository = mockk<IverksettingRepository>()
     private val brukernotifikasjonKafkaProducer = mockk<BrukernotifikasjonKafkaProducer>()
     private val taskService = mockk<TaskService>()
-    private val featureToggleService = mockFeatureToggleService()
     private val task =
         SendBrukernotifikasjonVedGOmregningTask(
             brukernotifikasjonKafkaProducer = brukernotifikasjonKafkaProducer,
             iverksettingRepository = iverksettingRepository,
             taskService = taskService,
-            featureToggleService = featureToggleService,
         )
 
     @BeforeEach
@@ -40,28 +37,17 @@ class SendBrukernotifikasjonVedGOmregningTaskTest {
                     opprettIverksettDto(behandlingId = UUID.randomUUID(), behandlingÅrsak = BehandlingÅrsak.G_OMREGNING).toDomain(),
                 ),
             )
-        every { brukernotifikasjonKafkaProducer.sendBeskjedTilBruker(any(), any()) } just runs
-        every { brukernotifikasjonKafkaProducer.sendBeskjedTilBrukerMedKotlinBuilder(any(), any(), any()) } just runs
+        every { brukernotifikasjonKafkaProducer.lagMelding(any()) } returns "test-tekst"
+        every { brukernotifikasjonKafkaProducer.sendBeskjedTilBruker(any(), any(), any(), any()) } just runs
     }
 
     @Nested
     inner class DoTaskTest {
         @Test
         fun `doTask - skal publisere vedtak til kafka`() {
-            every { featureToggleService.isEnabled(any()) } returns false
-
             task.doTask(Task(SendBrukernotifikasjonVedGOmregningTask.TYPE, UUID.randomUUID().toString()))
 
-            verify(exactly = 1) { brukernotifikasjonKafkaProducer.sendBeskjedTilBruker(any(), any()) }
-            verify(exactly = 0) { brukernotifikasjonKafkaProducer.sendBeskjedTilBrukerMedKotlinBuilder(any(), any(), any()) }
-        }
-
-        @Test
-        fun `doTask - skal publisere vedtak til kafka med Kotlin builder`() {
-            task.doTask(Task(SendBrukernotifikasjonVedGOmregningTask.TYPE, UUID.randomUUID().toString()))
-
-            verify(exactly = 0) { brukernotifikasjonKafkaProducer.sendBeskjedTilBruker(any(), any()) }
-            verify(exactly = 1) { brukernotifikasjonKafkaProducer.sendBeskjedTilBrukerMedKotlinBuilder(any(), any(), any()) }
+            verify(exactly = 1) { brukernotifikasjonKafkaProducer.sendBeskjedTilBruker(any(), any(), any(), any()) }
         }
     }
 }


### PR DESCRIPTION
# Brukernotifikasjon implementasjon med migerering er nå åpen for alle

**Hvorfor er denne endringen nødvendig? ✨** 

Etter diskurs med @olekvernberg så kom vi frem til at feature toggle egentlig ikke var nødvendig. Derfor har denne PRen fokus på å fjerne unødvendig feature toggle. Den endrer også litt grunn implementasjon av `sendBeskjedTilBruker` som nå tar inn en melding utenifra. Fjernet også unødvendig Kafka-config, siden den nye typen er nå `<String, String>`.  Fjernet også gammel brukernotifikasjon  dependency. 