### PR TITLE
Clone task -> restart

### DIFF
--- a/.deploy/nais-preprod.yaml
+++ b/.deploy/nais-preprod.yaml
@@ -49,6 +49,9 @@ spec:
         - application: familie-ef-sak-lokal
         - application: familie-prosessering
         - application: familie-ef-e2e
+        - application: azure-token-generator
+          namespace: nais
+          cluster: dev-gcp
     outbound:
       rules:
         - application: tilbakekreving-backend

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ App som tilbyr iverksettingstjenester av stønadene for enslige forsørgere.
 ## Swagger
 http://localhost:8094/swagger-ui/index.html
 
+"Bearer" + [Token]  
+Hent token til dev her: https://azure-token-generator.intern.dev.nav.no/api/m2m?aud=dev-gcp.teamfamilie.familie-ef-iverksett
+
 ## Bygging lokalt
 Appen kjører på JRE 11. Bygging gjøres ved å kjøre `mvn clean install`.
 

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/DistribuerVedtaksbrevTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/DistribuerVedtaksbrevTask.kt
@@ -24,7 +24,7 @@ import java.util.UUID
 @Service
 @TaskStepBeskrivelse(
     taskStepType = DistribuerVedtaksbrevTask.TYPE,
-    maxAntallFeil = 50,
+    maxAntallFeil = DistribuerVedtaksbrevTask.MAX_FORSØK,
     settTilManuellOppfølgning = true,
     triggerTidVedFeilISekunder = 15 * 60L,
     beskrivelse = "Distribuerer vedtaksbrev.",
@@ -141,5 +141,6 @@ class DistribuerVedtaksbrevTask(
 
     companion object {
         const val TYPE = "distribuerVedtaksbrev"
+        const val MAX_FORSØK = 50
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningController.kt
@@ -18,6 +18,29 @@ import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDateTime.now
 import java.util.Properties
 
+@RestController
+@RequestMapping(
+    path = ["/api/forvaltning/task"],
+    produces = [MediaType.APPLICATION_JSON_VALUE],
+)
+@ProtectedWithClaims(issuer = "azuread")
+class TaskForvaltningController(
+    private val taskService: TaskService,
+    private val taskForvaltningService: TaskForvaltningService,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @PostMapping("/restart/{taskId}")
+    fun hentStatus(
+        @PathVariable taskId: Long,
+    ): ResponseEntity<String> {
+        logger.info("Starter kloning av task id $taskId.")
+        val task = taskService.findById(taskId)
+        val lagretTask = taskForvaltningService.kopierTask(task)
+        return ResponseEntity("OK - opprettet ${lagretTask.id}, fra ${task.id}", HttpStatus.OK)
+    }
+}
+
 @Service
 class TaskForvaltningService(
     private val taskService: TaskService,
@@ -55,25 +78,3 @@ class TaskForvaltningService(
     }
 }
 
-@RestController
-@RequestMapping(
-    path = ["/api/forvaltning/task"],
-    produces = [MediaType.APPLICATION_JSON_VALUE],
-)
-@ProtectedWithClaims(issuer = "azuread")
-class TaskForvaltningController(
-    private val taskService: TaskService,
-    private val taskForvaltningService: TaskForvaltningService,
-) {
-    private val logger = LoggerFactory.getLogger(javaClass)
-
-    @PostMapping("/restart/{taskId}")
-    fun hentStatus(
-        @PathVariable taskId: Long,
-    ): ResponseEntity<String> {
-        logger.info("Starter kloning av task id $taskId.")
-        val task = taskService.findById(taskId)
-        val lagretTask = taskForvaltningService.kopierTask(task)
-        return ResponseEntity("OK - opprettet ${lagretTask.id}, fra ${task.id}", HttpStatus.OK)
-    }
-}

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningsController.kt
@@ -25,7 +25,6 @@ class TaskForvaltningService(
     private val taskService: TaskService,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
     @Transactional
     fun kopierTask(task: Task): Task {
@@ -35,10 +34,8 @@ class TaskForvaltningService(
         val kopiertTask = task.copy(id = 0L, versjon = 0L, triggerTid = LocalDateTime.now().plusMinutes(15), metadataWrapper = PropertiesWrapper(kopierProperties))
 
         taskService.save(task.copy(payload = "${task.payload}-klonetTilNy")) // Oppdaterer den originale tasken med et suffiks for å indikere at den er klonet
-        secureLogger.info(kopiertTask.toString())
         val lagretTask = taskService.save(kopiertTask)
-
-        logger.info("Kloner task med id ${task.id}. Opprettet ny task: ${lagretTask.id}")
+        logger.info("Klonet task med id ${task.id}. Opprettet ny task: ${lagretTask.id}")
         return lagretTask
     }
 
@@ -46,6 +43,7 @@ class TaskForvaltningService(
         val newProps = Properties()
         newProps.putAll(task.metadata)
         newProps.setProperty(MDCConstants.MDC_CALL_ID, IdUtils.generateId())
+        newProps.setProperty("Info", "Kopiert fra task med id ${task.id}")
         return newProps
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningsController.kt
@@ -4,8 +4,6 @@ import no.nav.familie.prosessering.domene.PropertiesWrapper
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
-import no.nav.familie.prosessering.util.IdUtils
-import no.nav.familie.prosessering.util.MDCConstants
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -36,7 +34,6 @@ class TaskForvaltningService(
         val gamleProperties = oppdaterGamleProperties(task)
         taskService.save(task.copy(payload = "${now()}", metadataWrapper = PropertiesWrapper(gamleProperties)))
 
-
         val lagretTask = taskService.save(kopiertTask)
         logger.info("Klonet task med id ${task.id}. Opprettet ny task: ${lagretTask.id}")
         return lagretTask
@@ -53,7 +50,6 @@ class TaskForvaltningService(
     private fun kopierProperties(task: Task): Properties {
         val newProps = Properties()
         newProps.putAll(task.metadata)
-        newProps.setProperty(MDCConstants.MDC_CALL_ID, IdUtils.generateId())
         newProps.setProperty("Info", "Kopiert fra task med id ${task.id}")
         return newProps
     }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningsController.kt
@@ -1,0 +1,47 @@
+package no.nav.familie.ef.iverksett.infrastruktur.task
+
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.internal.TaskService
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDateTime
+import kotlin.reflect.full.findAnnotation
+
+@RestController
+@RequestMapping(
+    path = ["/api/forvaltning/task"],
+    produces = [MediaType.APPLICATION_JSON_VALUE],
+)
+@ProtectedWithClaims(issuer = "azuread")
+class TaskForvaltningsController(
+    private val taskService: TaskService,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+
+    @PostMapping("/restart/{taskId}")
+    fun hentStatus(
+        @PathVariable taskId: Long,
+    ): ResponseEntity<String> {
+        val task = taskService.findById(taskId)
+
+        val annotation = task::class.findAnnotation<TaskStepBeskrivelse>()
+        val maxAntallFeil = annotation?.maxAntallFeil ?: 3
+        val antallGangerPlukket = taskService.antallGangerPlukket(taskId)
+
+        check(antallGangerPlukket > maxAntallFeil){"Tasken kan ikke plukkes på nytt, da den ikke er plukket for mange ganger: $antallGangerPlukket"}
+
+        val nyTask = task.copy(id = 0L, triggerTid = LocalDateTime.now().plusMinutes(15))
+        val lagretTask = taskService.save(nyTask) // For å restarte tasken, må vi sette id til 0, slik at den blir opprettet på nytt
+
+        logger.info("Kloner task med id ${task.id}. Opprettet ny task: ${lagretTask.id}")
+        return ResponseEntity("OK - opprettet ${lagretTask.id}", HttpStatus.OK)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningsController.kt
@@ -28,18 +28,16 @@ class TaskForvaltningsController(
     private val logger = LoggerFactory.getLogger(javaClass)
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
-
     @PostMapping("/restart/{taskId}")
     @Transactional
     fun hentStatus(
         @PathVariable taskId: Long,
     ): ResponseEntity<String> {
-
-        logger.info("Starter kloning av task id ${taskId}.")
+        logger.info("Starter kloning av task id $taskId.")
 
         val task = taskService.findById(taskId)
 
-        check(task.status==Status.MANUELL_OPPFØLGING) { "Task må ha status MANUELL_OPPFØLGING" }
+        check(task.status == Status.MANUELL_OPPFØLGING) { "Task må ha status MANUELL_OPPFØLGING" }
         logger.info("Fant task: ${task.id} med type ${task.type}.")
 
         val annotation = task::class.findAnnotation<TaskStepBeskrivelse>()
@@ -48,14 +46,13 @@ class TaskForvaltningsController(
 
         logger.info("Tasken har blitt plukket $antallGangerPlukket ganger. Maks antall feil tillatt: $maxAntallFeil.")
 
-        check(antallGangerPlukket > maxAntallFeil){"Tasken kan ikke plukkes på nytt, da den ikke er plukket for mange ganger: $antallGangerPlukket"}
+        check(antallGangerPlukket > maxAntallFeil) { "Tasken kan ikke plukkes på nytt, da den ikke er plukket for mange ganger: $antallGangerPlukket" }
 
         val nyTask = task.copy(id = 0L, triggerTid = LocalDateTime.now().plusMinutes(15))
 
-
         secureLogger.info(nyTask.toString())
 
-        taskService.save(task.copy(payload = task.payload+"-konet"))
+        taskService.save(task.copy(payload = task.payload + "-konet"))
         val lagretTask = taskService.save(nyTask) // For å restarte tasken, må vi sette id til 0, slik at den blir opprettet på nytt
 
         logger.info("Kloner task med id ${task.id}. Opprettet ny task: ${lagretTask.id}")

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningsController.kt
@@ -1,20 +1,41 @@
 package no.nav.familie.ef.iverksett.infrastruktur.task
 
-import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Status
+import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDateTime
-import kotlin.reflect.full.findAnnotation
+
+@Service
+class TaskForvaltningService(
+    private val taskService: TaskService,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+
+    @Transactional
+    fun kopierTask(task: Task): Task {
+        check(task.status == Status.MANUELL_OPPFØLGING) { "Task som skal kopieres må ha status MANUELL_OPPFØLGING" }
+        val nyTask = task.copy(id = 0L, versjon = 0L, triggerTid = LocalDateTime.now().plusMinutes(15))
+
+        taskService.save(task.copy(payload = "${task.payload}-klonetTilNy"))
+        secureLogger.info(nyTask.toString())
+        val lagretTask = taskService.save(nyTask)
+
+        logger.info("Kloner task med id ${task.id}. Opprettet ny task: ${lagretTask.id}")
+        return lagretTask
+    }
+}
 
 @RestController
 @RequestMapping(
@@ -24,38 +45,17 @@ import kotlin.reflect.full.findAnnotation
 @ProtectedWithClaims(issuer = "azuread")
 class TaskForvaltningsController(
     private val taskService: TaskService,
+    private val taskForvaltningService: TaskForvaltningService,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
     @PostMapping("/restart/{taskId}")
-    @Transactional
     fun hentStatus(
         @PathVariable taskId: Long,
     ): ResponseEntity<String> {
         logger.info("Starter kloning av task id $taskId.")
-
         val task = taskService.findById(taskId)
-
-        check(task.status == Status.MANUELL_OPPFØLGING) { "Task må ha status MANUELL_OPPFØLGING" }
-        logger.info("Fant task: ${task.id} med type ${task.type}.")
-
-        val annotation = task::class.findAnnotation<TaskStepBeskrivelse>()
-        val maxAntallFeil = annotation?.maxAntallFeil ?: 3
-        val antallGangerPlukket = taskService.antallGangerPlukket(taskId)
-
-        logger.info("Tasken har blitt plukket $antallGangerPlukket ganger. Maks antall feil tillatt: $maxAntallFeil.")
-
-        check(antallGangerPlukket > maxAntallFeil) { "Tasken kan ikke plukkes på nytt, da den ikke er plukket for mange ganger: $antallGangerPlukket" }
-
-        val nyTask = task.copy(id = 0L, triggerTid = LocalDateTime.now().plusMinutes(15))
-
-        secureLogger.info(nyTask.toString())
-
-        taskService.save(task.copy(payload = task.payload + "-konet"))
-        val lagretTask = taskService.save(nyTask) // For å restarte tasken, må vi sette id til 0, slik at den blir opprettet på nytt
-
-        logger.info("Kloner task med id ${task.id}. Opprettet ny task: ${lagretTask.id}")
-        return ResponseEntity("OK - opprettet ${lagretTask.id}", HttpStatus.OK)
+        val lagretTask = taskForvaltningService.kopierTask(task)
+        return ResponseEntity("OK - opprettet ${lagretTask.id}, fra ${task.id}", HttpStatus.OK)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningsController.kt
@@ -61,7 +61,7 @@ class TaskForvaltningService(
     produces = [MediaType.APPLICATION_JSON_VALUE],
 )
 @ProtectedWithClaims(issuer = "azuread")
-class TaskForvaltningsController(
+class TaskForvaltningController(
     private val taskService: TaskService,
     private val taskForvaltningService: TaskForvaltningService,
 ) {

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningsController.kt
@@ -1,8 +1,11 @@
 package no.nav.familie.ef.iverksett.infrastruktur.task
 
+import no.nav.familie.prosessering.domene.PropertiesWrapper
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
+import no.nav.familie.prosessering.util.IdUtils
+import no.nav.familie.prosessering.util.MDCConstants
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -15,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDateTime
+import java.util.Properties
 
 @Service
 class TaskForvaltningService(
@@ -26,14 +30,23 @@ class TaskForvaltningService(
     @Transactional
     fun kopierTask(task: Task): Task {
         check(task.status == Status.MANUELL_OPPFØLGING) { "Task som skal kopieres må ha status MANUELL_OPPFØLGING" }
-        val nyTask = task.copy(id = 0L, versjon = 0L, triggerTid = LocalDateTime.now().plusMinutes(15))
 
-        taskService.save(task.copy(payload = "${task.payload}-klonetTilNy"))
-        secureLogger.info(nyTask.toString())
-        val lagretTask = taskService.save(nyTask)
+        val kopierProperties = kopierProperties(task)
+        val kopiertTask = task.copy(id = 0L, versjon = 0L, triggerTid = LocalDateTime.now().plusMinutes(15), metadataWrapper = PropertiesWrapper(kopierProperties))
+
+        taskService.save(task.copy(payload = "${task.payload}-klonetTilNy")) // Oppdaterer den originale tasken med et suffiks for å indikere at den er klonet
+        secureLogger.info(kopiertTask.toString())
+        val lagretTask = taskService.save(kopiertTask)
 
         logger.info("Kloner task med id ${task.id}. Opprettet ny task: ${lagretTask.id}")
         return lagretTask
+    }
+
+    private fun kopierProperties(task: Task): Properties {
+        val newProps = Properties()
+        newProps.putAll(task.metadata)
+        newProps.setProperty(MDCConstants.MDC_CALL_ID, IdUtils.generateId())
+        return newProps
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningsController.kt
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -29,6 +30,7 @@ class TaskForvaltningsController(
 
 
     @PostMapping("/restart/{taskId}")
+    @Transactional
     fun hentStatus(
         @PathVariable taskId: Long,
     ): ResponseEntity<String> {
@@ -49,8 +51,11 @@ class TaskForvaltningsController(
         check(antallGangerPlukket > maxAntallFeil){"Tasken kan ikke plukkes på nytt, da den ikke er plukket for mange ganger: $antallGangerPlukket"}
 
         val nyTask = task.copy(id = 0L, triggerTid = LocalDateTime.now().plusMinutes(15))
+
+
         secureLogger.info(nyTask.toString())
 
+        taskService.save(task.copy(payload = task.payload+"-konet"))
         val lagretTask = taskService.save(nyTask) // For å restarte tasken, må vi sette id til 0, slik at den blir opprettet på nytt
 
         logger.info("Kloner task med id ${task.id}. Opprettet ny task: ${lagretTask.id}")

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningServiceTest.kt
@@ -42,7 +42,6 @@ class TaskForvaltningServiceTest : ServerTest() {
     internal fun `Klon eksisterende task`() {
         val task = taskService.findById(taskId)
         assertThat(taskService.antallGangerPlukket(task.id)).isEqualTo(DistribuerVedtaksbrevTask.MAX_FORSØK)
-
         val kopi = taskForvaltningService.kopierTask(task)
 
         val orginalTaskFraDb = taskService.findById(taskId)
@@ -51,8 +50,7 @@ class TaskForvaltningServiceTest : ServerTest() {
         assertThat(taskService.antallGangerPlukket(kopi.id)).isEqualTo(0)
         assertThat(kopi.payload).isEqualTo(payload)
         assertThat(kopi.versjon).isEqualTo(1)
-
-        assertThat(kopi.callId).isNotEqualTo(orginalTaskFraDb.callId)
+        assertThat(kopi.callId).isEqualTo(orginalTaskFraDb.callId)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningServiceTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDateTime
+import java.time.LocalDateTime.now
 import java.util.UUID
 
 class TaskForvaltningServiceTest : ServerTest() {
@@ -45,7 +46,14 @@ class TaskForvaltningServiceTest : ServerTest() {
         val kopi = taskForvaltningService.kopierTask(task)
 
         val orginalTaskFraDb = taskService.findById(taskId)
-        assertThat(orginalTaskFraDb.payload).isEqualTo(payload + "-klonetTilNy")
+
+        println("orginalTaskFraDb ---------------------")
+        println(orginalTaskFraDb)
+        println("payload: ${orginalTaskFraDb.payload}")
+        println(orginalTaskFraDb.metadata)
+        println("slutt ---------------------")
+
+        assertThat(LocalDateTime.parse(orginalTaskFraDb.payload)).isBeforeOrEqualTo(now())
         assertThat(taskService.antallGangerPlukket(kopi.id)).isEqualTo(0)
         assertThat(kopi.payload).isEqualTo(payload)
         assertThat(kopi.versjon).isEqualTo(1)
@@ -61,7 +69,7 @@ class TaskForvaltningServiceTest : ServerTest() {
         assertThrows<IllegalStateException> { taskForvaltningService.kopierTask(task) }
     }
 
-    private fun lagTask(): Task = Task(type = DistribuerVedtaksbrevTask.TYPE, payload = this.payload, status = Status.UBEHANDLET).medTriggerTid(LocalDateTime.now().minusDays(1))
+    private fun lagTask(): Task = Task(type = DistribuerVedtaksbrevTask.TYPE, payload = this.payload, status = Status.UBEHANDLET).medTriggerTid(now().minusDays(1))
 
     private fun kjørTaskSomFeilerTilStatusBlirMANUELL_OPPFØLGING(taskId: Long) {
         taskService.findById(taskId)

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningServiceTest.kt
@@ -1,0 +1,69 @@
+package no.nav.familie.ef.iverksett.infrastruktur.task
+
+import jakarta.annotation.PostConstruct
+import no.nav.familie.ef.iverksett.ServerTest
+import no.nav.familie.ef.iverksett.brev.DistribuerVedtaksbrevTask
+import no.nav.familie.prosessering.domene.Status
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.internal.TaskService
+import no.nav.familie.prosessering.internal.TaskWorker
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDateTime
+import java.util.*
+
+class TaskForvaltningServiceTest : ServerTest() {
+    @Autowired
+    private lateinit var taskService: TaskService
+
+    @Autowired
+    private lateinit var taskForvaltningService: TaskForvaltningService
+
+    @Autowired
+    private lateinit var taskWorker: TaskWorker
+
+    var taskId: Long = 0
+
+    val payload = UUID.randomUUID().toString()
+
+    @PostConstruct
+    fun init() {
+        val savedTask = taskService.save(lagTask())
+        assertThat(savedTask.status).isEqualTo(Status.UBEHANDLET)
+        taskId = savedTask.id
+        kjørTask(taskId)
+    }
+
+    @Test
+    internal fun `Klon eksisterende task`() {
+        val task = taskService.findById(taskId)
+        assertThat(taskService.antallGangerPlukket(task.id)).isEqualTo(DistribuerVedtaksbrevTask.MAX_FORSØK)
+
+        val kopi = taskForvaltningService.kopierTask(task)
+
+        val orginalTaskFraDb = taskService.findById(taskId)
+        assertThat(orginalTaskFraDb.payload).isEqualTo(payload + "-klonetTilNy")
+        assertThat(taskService.antallGangerPlukket(kopi.id)).isEqualTo(0)
+        assertThat(kopi.payload).isEqualTo(payload)
+        assertThat(kopi.versjon).isEqualTo(1)
+    }
+
+    private fun lagTask(): Task = Task(type = DistribuerVedtaksbrevTask.TYPE, payload = this.payload, status = Status.UBEHANDLET).medTriggerTid(LocalDateTime.now().minusDays(1))
+
+    private fun kjørTask(taskId: Long) {
+        taskService.findById(taskId)
+        repeat(52, { doWork(taskId) })
+    }
+
+    fun doWork(taskId: Long) {
+        try {
+            taskWorker.markerPlukket(taskId)
+            println("Nytt forsøk")
+            taskWorker.doActualWork(taskId)
+        } catch (e: IllegalStateException) {
+            // forventet å få feil her
+            taskWorker.doFeilhåndtering(taskId, e)
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningServiceTest.kt
@@ -11,7 +11,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDateTime
-import java.util.*
+import java.util.UUID
+
 
 class TaskForvaltningServiceTest : ServerTest() {
     @Autowired

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/infrastruktur/task/TaskForvaltningServiceTest.kt
@@ -47,12 +47,6 @@ class TaskForvaltningServiceTest : ServerTest() {
 
         val orginalTaskFraDb = taskService.findById(taskId)
 
-        println("orginalTaskFraDb ---------------------")
-        println(orginalTaskFraDb)
-        println("payload: ${orginalTaskFraDb.payload}")
-        println(orginalTaskFraDb.metadata)
-        println("slutt ---------------------")
-
         assertThat(LocalDateTime.parse(orginalTaskFraDb.payload)).isBeforeOrEqualTo(now())
         assertThat(taskService.antallGangerPlukket(kopi.id)).isEqualTo(0)
         assertThat(kopi.payload).isEqualTo(payload)


### PR DESCRIPTION
Se [favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-25826): 

Dersom en task havner i manuell oppfølging etter for mange feil kan vi ha behov for å resette feilcounter.
Ref feil i prod: 
`MaxAntallRekjøringerException(maxAntallRekjøring=50)
	at no.nav.familie.prosessering.internal.TaskWorker.rekjørSenere(TaskWorker.kt:116)`

 
Antall feil regnes i task-rammeverk ut ved å telle antall ganger en task er plukket. Heller enn å slette task_loggs ønsker jeg her å kopierer task, men uten å kopiere logg + versjon. 

Kun mulig å kopiere task som ligger i manuell oppfølging. (Den kopierte tasken vil bli ubrukelig etter kopi - se payload under) 

Legger til ny callId på den kopierte tasken så vi kan spore denne for seg? Vet ikke om dette er hensiktsmessig? Kan kanskje være greit om de er like for grupperingens del? Hva tror dere? 

Legger til litt info om hvor den er kopiert fra. Flytter payload på gammel task til metadata da payload må endres (unique constraint på denne i db)Legger inn LocalDateTime.now() her.  

Testet i preprod med: 

https://familie-ef-iverksett.intern.dev.nav.no/swagger-ui/index.html#/task-forvaltnings-controller
https://azure-token-generator.intern.dev.nav.no/api/m2m?aud=dev-gcp.teamfamilie.familie-ef-iverksett

Resultat i prosessering: 
https://familie-prosessering.intern.dev.nav.no/service/familie-ef-iverksett/task/72413 orginal
https://familie-prosessering.intern.dev.nav.no/service/familie-ef-iverksett/task/72414 kopi
(ps ingen av disse vil fungere - annen urelatert feil her) 