### PR TITLE
Bug i surefire-versjon som gjør at maven ikke rapporterer feilende cucumber-tester

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <prosessering.version>2.20250718105310_e1cba2a</prosessering.version>
         <utbetalingsgenerator.version>1.0_20250415144931_0dc88d8</utbetalingsgenerator.version>
         <brukervarsel-builder.version>2.1.1</brukervarsel-builder.version>
-        <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
         <confluent.version>8.0.0</confluent.version>
         <mockk-jvm.version>1.14.5</mockk-jvm.version>
         <cucumber.version>7.26.0</cucumber.version>


### PR DESCRIPTION
Nedgraderer derfor maven surefire versjonen midlertidig.

Det er diskutert her: https://github.com/cucumber/cucumber-jvm/issues/2984