### PR TITLE
Tusenskille på grunnbeløp

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducer.kt
@@ -11,6 +11,9 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.UUID
@@ -77,8 +80,17 @@ class BrukernotifikasjonKafkaProducer(
 
     fun lagMelding(iverksett: IverksettOvergangsstønad): String =
         iverksett.vedtak.grunnbeløp?.let {
-            """Fra ${it.periode.fomDato.norskFormat()} har folketrygdens grunnbeløp økt til ${it.grunnbeløp} kroner og overgangsstønaden din er derfor endret. Se nav.no/minside for detaljer.""".trimIndent()
+            """Fra ${it.periode.fomDato.norskFormat()} har folketrygdens grunnbeløp økt til ${medTusenskille(it.grunnbeløp)} kroner og overgangsstønaden din er derfor endret. Se nav.no/minside for detaljer.""".trimIndent()
         } ?: throw IllegalStateException("Mangler grunnbeløp")
 }
 
 private fun LocalDate.norskFormat() = this.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))
+
+private fun medTusenskille(
+    verdi: BigDecimal,
+): String {
+    val symbols = DecimalFormatSymbols.getInstance()
+    symbols.groupingSeparator = ' '
+    val formatter = DecimalFormat("###,###", symbols)
+    return formatter.format(verdi.toLong())
+}

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brukernotifikasjon/BrukernotifikasjonKafkaProducerTest.kt
@@ -34,7 +34,7 @@ class BrukernotifikasjonKafkaProducerTest {
 
     @Nested
     inner class GenererNotifikasjonMelding {
-        val forventetGOmregningTekst = "Fra 01.05.2023 har folketrygdens grunnbeløp økt til 118620 kroner og overgangsstønaden din er derfor endret. Se nav.no/minside for detaljer."
+        val forventetGOmregningTekst = "Fra 01.05.2023 har folketrygdens grunnbeløp økt til 118 620 kroner og overgangsstønaden din er derfor endret. Se nav.no/minside for detaljer."
         val iverksettRevurderingInnvilget =
             lagIverksettData(
                 behandlingType = BehandlingType.REVURDERING,


### PR DESCRIPTION
Legger til tusenskille i grunnbeløpet i melding på nav.no til bruker ved g-omregning.
<img width="599" height="655" alt="Screenshot 2026-05-21 at 10 55 07" src="https://github.com/user-attachments/assets/af508383-5e91-4434-8dfb-bb8c1b8230a6" />
