### PR TITLE
Tydeliggjør hva som er group-id

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/TilbakekrevingListener.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/tilbakekreving/TilbakekrevingListener.kt
@@ -29,6 +29,7 @@ class TilbakekrevingListener(
         id = "familie-ef-iverksett",
         topics = ["\${FAGSYSTEMBEHANDLING_REQUEST_TOPIC}"],
         containerFactory = "concurrentTilbakekrevingListenerContainerFactory",
+        groupId = "familie-ef-iverksett",
     )
     fun listen(consumerRecord: ConsumerRecord<String, String>) {
         val key: String = consumerRecord.key()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,7 +55,6 @@ spring:
     consumer:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      group-id: srvfamilie-ef-iverks
       max-poll-records: 1
       auto-offset-reset: latest
       enable-auto-commit: false


### PR DESCRIPTION
Hvis man setter id i listener, overstyrer den group id i application.yml, noe som kan være litt overraskende. Gjør config mer tydelig. Dette er verifisert gjennom metrikker i Grafana.