### PR TITLE
Skal ikke sende vedlegg om rettigheter på OS regelendring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <java.version>21</java.version>
         <kotlin.version>2.3.21</kotlin.version>
         <felles.version>4.20260529121328_2754f7c</felles.version>
-        <familie.kontrakter.version>4.0_20260527090809_893fcba</familie.kontrakter.version>
+        <familie.kontrakter.version>4.0_20260605100546_f529556</familie.kontrakter.version>
         <familie.eksterne-kontrakter.stonadsstatistikk-ef>2.0_20260323170751_4c02e3c</familie.eksterne-kontrakter.stonadsstatistikk-ef>
         <familie.eksterne-kontrakter.saksstatistikk-ef>2.0_20260323170751_4c02e3c</familie.eksterne-kontrakter.saksstatistikk-ef>
         <familie.eksterne-kontrakter.arbeidsoppfolging>2.0_20260323170751_4c02e3c</familie.eksterne-kontrakter.arbeidsoppfolging>

--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,9 @@
         <kotlin.version>2.3.21</kotlin.version>
         <felles.version>4.20260529121328_2754f7c</felles.version>
         <familie.kontrakter.version>4.0_20260605100546_f529556</familie.kontrakter.version>
-        <familie.eksterne-kontrakter.stonadsstatistikk-ef>2.0_20260323170751_4c02e3c</familie.eksterne-kontrakter.stonadsstatistikk-ef>
-        <familie.eksterne-kontrakter.saksstatistikk-ef>2.0_20260323170751_4c02e3c</familie.eksterne-kontrakter.saksstatistikk-ef>
-        <familie.eksterne-kontrakter.arbeidsoppfolging>2.0_20260323170751_4c02e3c</familie.eksterne-kontrakter.arbeidsoppfolging>
+        <familie.eksterne-kontrakter.stonadsstatistikk-ef>2.0_20260608131536_fcc5cc6</familie.eksterne-kontrakter.stonadsstatistikk-ef>
+        <familie.eksterne-kontrakter.saksstatistikk-ef>2.0_20260608131536_fcc5cc6</familie.eksterne-kontrakter.saksstatistikk-ef>
+        <familie.eksterne-kontrakter.arbeidsoppfolging>2.0_20260608131536_fcc5cc6</familie.eksterne-kontrakter.arbeidsoppfolging>
         <prosessering.version>2.20260526102747_ed05f71</prosessering.version>
         <utbetalingsgenerator.version>1.0_20260527092003_ed16208</utbetalingsgenerator.version>
         <brukervarsel-builder.version>2.2.0</brukervarsel-builder.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <java.version>21</java.version>
         <kotlin.version>2.3.21</kotlin.version>
         <felles.version>4.20260529121328_2754f7c</felles.version>
-        <familie.kontrakter.version>4.0_20260605100546_f529556</familie.kontrakter.version>
+        <familie.kontrakter.version>4.0_20260608075026_1c29629</familie.kontrakter.version>
         <familie.eksterne-kontrakter.stonadsstatistikk-ef>2.0_20260608131536_fcc5cc6</familie.eksterne-kontrakter.stonadsstatistikk-ef>
         <familie.eksterne-kontrakter.saksstatistikk-ef>2.0_20260608131536_fcc5cc6</familie.eksterne-kontrakter.saksstatistikk-ef>
         <familie.eksterne-kontrakter.arbeidsoppfolging>2.0_20260608131536_fcc5cc6</familie.eksterne-kontrakter.arbeidsoppfolging>

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/JournalførVedtaksbrevTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/JournalførVedtaksbrevTask.kt
@@ -134,8 +134,10 @@ class JournalførVedtaksbrevTask(
         }
     }
 
-    private fun skalHaVedleggOmRettigheter(iverksett: Iverksett): Boolean =
-        when (iverksett.data.behandling.behandlingÅrsak) {
+    private fun skalHaVedleggOmRettigheter(iverksett: Iverksett): Boolean {
+        if (iverksett.data.behandling.erRegelendring2026) return false
+
+        return when (iverksett.data.behandling.behandlingÅrsak) {
             BehandlingÅrsak.G_OMREGNING -> false
             BehandlingÅrsak.MIGRERING -> false
             BehandlingÅrsak.SATSENDRING -> false
@@ -143,6 +145,7 @@ class JournalførVedtaksbrevTask(
             BehandlingÅrsak.KORRIGERING_UTEN_BREV -> false
             else -> iverksett.data.vedtak.vedtaksresultat == Vedtaksresultat.INNVILGET
         }
+    }
 
     private fun vedleggsdokumentForStønad(stønadType: StønadType): List<Dokument> {
         val pdf = lesPdfForVedleggForRettigheter(stønadType)

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/transformer/IverksettDtoToDomain.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/infrastruktur/transformer/IverksettDtoToDomain.kt
@@ -80,6 +80,7 @@ fun BehandlingsdetaljerDto.toDomain(): Behandlingsdetaljer =
         kravMottatt = this.kravMottatt,
         årsakRevurdering = this.årsakRevurdering?.let { ÅrsakRevurdering(it.opplysningskilde, it.årsak) },
         kategori = this.kategori,
+        erRegelendring2026 = this.erRegelendring2026,
     )
 
 fun VedtaksperiodeOvergangsstønadDto.toDomain(): VedtaksperiodeOvergangsstønad =

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/domene/IverksettData.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/iverksetting/domene/IverksettData.kt
@@ -233,6 +233,7 @@ data class Behandlingsdetaljer(
     val kravMottatt: LocalDate? = null,
     val årsakRevurdering: ÅrsakRevurdering? = null,
     val kategori: BehandlingKategori? = null,
+    val erRegelendring2026: Boolean = false,
 )
 
 data class ÅrsakRevurdering(


### PR DESCRIPTION
I dag sender vi et vedlegg sammen med vedtaksbrev om innvilgelse og revurdering (ikke opphør og avslag). Vedlegget inneholder rettigheter og plikter bruker har. Ifølge den nye brevstandarden skal plikter som bruker har stå i selve vedtaksbrevet.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29243)