### PR TITLE
Mapping behandlingstype med erRegelendring2026 behandlingsstatistikk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <java.version>21</java.version>
         <kotlin.version>2.4.0</kotlin.version>
         <felles.version>4.20260529121328_2754f7c</felles.version>
-        <familie.kontrakter.version>4.0_20260608075026_1c29629</familie.kontrakter.version>
+        <familie.kontrakter.version>4.0_20260611084408_a47ed94</familie.kontrakter.version>
         <familie.eksterne-kontrakter.stonadsstatistikk-ef>2.0_20260608131536_fcc5cc6</familie.eksterne-kontrakter.stonadsstatistikk-ef>
         <familie.eksterne-kontrakter.saksstatistikk-ef>2.0_20260608131536_fcc5cc6</familie.eksterne-kontrakter.saksstatistikk-ef>
         <familie.eksterne-kontrakter.arbeidsoppfolging>2.0_20260608131536_fcc5cc6</familie.eksterne-kontrakter.arbeidsoppfolging>

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/behandlingsstatistikk/BehandlingsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/behandlingsstatistikk/BehandlingsstatistikkService.kt
@@ -176,7 +176,7 @@ class BehandlingsstatistikkService(
     private fun mapTilBehandlingTypeMedRegelendringStreng(
         behandlingType: BehandlingType,
         erRegelEndring2026: Boolean,
-    ) = if (erRegelEndring2026) behandlingType.name + "_ERREGELENDRING2026" else behandlingType.name
+    ) = if (erRegelEndring2026) behandlingType.name + "_ER_REGELENDRING_2026" else behandlingType.name
 
     companion object {
         const val MASKINELL_JOURNALFOERENDE_ENHET = "9999"

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/behandlingsstatistikk/BehandlingsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/behandlingsstatistikk/BehandlingsstatistikkService.kt
@@ -176,7 +176,7 @@ class BehandlingsstatistikkService(
     private fun mapTilBehandlingTypeMedRegelendringStreng(
         behandlingType: BehandlingType,
         erRegelEndring2026: Boolean,
-    ) = if (erRegelEndring2026) behandlingType.name + "_erRegelendring2026" else behandlingType.name
+    ) = if (erRegelEndring2026) behandlingType.name + "_ERREGELENDRING2026" else behandlingType.name
 
     companion object {
         const val MASKINELL_JOURNALFOERENDE_ENHET = "9999"

--- a/src/main/kotlin/no/nav/familie/ef/iverksett/behandlingsstatistikk/BehandlingsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/behandlingsstatistikk/BehandlingsstatistikkService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.iverksett.behandlingsstatistikk
 import no.nav.familie.ef.iverksett.iverksetting.domene.IverksettOvergangsstønad
 import no.nav.familie.eksterne.kontrakter.ef.BehandlingÅrsak
 import no.nav.familie.eksterne.kontrakter.saksstatistikk.ef.BehandlingDVH
+import no.nav.familie.kontrakter.ef.felles.BehandlingType
 import no.nav.familie.kontrakter.ef.iverksett.AdressebeskyttelseGradering
 import no.nav.familie.kontrakter.ef.iverksett.BehandlingKategori
 import no.nav.familie.kontrakter.ef.iverksett.BehandlingMetode
@@ -113,7 +114,7 @@ class BehandlingsstatistikkService(
             behandlingMetode = behandlingsstatistikkDto.behandlingMetode?.name ?: "MANUELL",
             behandlingÅrsak = behandlingsstatistikkDto.behandlingÅrsak.name,
             avsender = "NAV enslig forelder",
-            behandlingType = behandlingsstatistikkDto.behandlingstype.name,
+            behandlingType = mapTilBehandlingTypeMedRegelendringStreng(behandlingsstatistikkDto.behandlingstype, behandlingsstatistikkDto.erRegelEndring2026),
             sakYtelse = behandlingsstatistikkDto.stønadstype.name,
             behandlingResultat = behandlingsstatistikkDto.behandlingResultat,
             resultatBegrunnelse = behandlingsstatistikkDto.resultatBegrunnelse,
@@ -171,6 +172,11 @@ class BehandlingsstatistikkService(
             BehandlingKategori.NASJONAL -> "Nasjonal"
             null -> "Nasjonal"
         }
+
+    private fun mapTilBehandlingTypeMedRegelendringStreng(
+        behandlingType: BehandlingType,
+        erRegelEndring2026: Boolean,
+    ) = if (erRegelEndring2026) behandlingType.name + "_erRegelendring2026" else behandlingType.name
 
     companion object {
         const val MASKINELL_JOURNALFOERENDE_ENHET = "9999"

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/behandlingsstatistikk/BehandlingsstatistikkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/behandlingsstatistikk/BehandlingsstatistikkServiceTest.kt
@@ -161,7 +161,7 @@ internal class BehandlingsstatistikkServiceTest {
 
             behandlingstatistikkService.sendBehandlingstatistikk(dto)
 
-            assertThat(captureSlot.captured.behandlingType).isEqualTo("${behandlingType.name}_ERREGELENDRING2026")
+            assertThat(captureSlot.captured.behandlingType).isEqualTo("${behandlingType.name}_ER_REGELENDRING_2026")
         }
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/behandlingsstatistikk/BehandlingsstatistikkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/behandlingsstatistikk/BehandlingsstatistikkServiceTest.kt
@@ -8,6 +8,7 @@ import io.mockk.slot
 import no.nav.familie.ef.iverksett.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.iverksett.util.opprettBehandlingsstatistikkDto
 import no.nav.familie.eksterne.kontrakter.saksstatistikk.ef.BehandlingDVH
+import no.nav.familie.kontrakter.ef.felles.BehandlingType
 import no.nav.familie.kontrakter.ef.felles.Opplysningskilde
 import no.nav.familie.kontrakter.ef.felles.Revurderingsårsak
 import no.nav.familie.kontrakter.ef.iverksett.Hendelse
@@ -149,5 +150,31 @@ internal class BehandlingsstatistikkServiceTest {
         assertThat(captureSlot.captured.opprettetAv).isEqualTo("-5")
         assertThat(captureSlot.captured.opprettetEnhet).isEqualTo("-5")
         assertThat(captureSlot.captured.ansvarligEnhet).isEqualTo("-5")
+    }
+
+    @Test
+    fun `sendBehandlingsstatistikkDto med erRegelEndring2026 lik true, legger til suffiks på behandlingType`() {
+        listOf(BehandlingType.FØRSTEGANGSBEHANDLING, BehandlingType.REVURDERING).forEach { behandlingType ->
+            val dto =
+                opprettBehandlingsstatistikkDto(UUID.randomUUID(), Hendelse.MOTTATT, fortrolig = false)
+                    .copy(behandlingstype = behandlingType, erRegelEndring2026 = true)
+
+            behandlingstatistikkService.sendBehandlingstatistikk(dto)
+
+            assertThat(captureSlot.captured.behandlingType).isEqualTo("${behandlingType.name}_erRegelendring2026")
+        }
+    }
+
+    @Test
+    fun `sendBehandlingsstatistikkDto med erRegelEndring2026 lik false, beholder opprinnelig behandlingType`() {
+        listOf(BehandlingType.FØRSTEGANGSBEHANDLING, BehandlingType.REVURDERING).forEach { behandlingType ->
+            val dto =
+                opprettBehandlingsstatistikkDto(UUID.randomUUID(), Hendelse.MOTTATT, fortrolig = false)
+                    .copy(behandlingstype = behandlingType, erRegelEndring2026 = false)
+
+            behandlingstatistikkService.sendBehandlingstatistikk(dto)
+
+            assertThat(captureSlot.captured.behandlingType).isEqualTo(behandlingType.name)
+        }
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/behandlingsstatistikk/BehandlingsstatistikkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/behandlingsstatistikk/BehandlingsstatistikkServiceTest.kt
@@ -161,7 +161,7 @@ internal class BehandlingsstatistikkServiceTest {
 
             behandlingstatistikkService.sendBehandlingstatistikk(dto)
 
-            assertThat(captureSlot.captured.behandlingType).isEqualTo("${behandlingType.name}_erRegelendring2026")
+            assertThat(captureSlot.captured.behandlingType).isEqualTo("${behandlingType.name}_ERREGELENDRING2026")
         }
     }
 


### PR DESCRIPTION
Legger til _erRegelEndring2026 på behandlingsstype strengen som sendes til behandlingsstatistikk for å gi info om behandling følger nytt eller gammelt regelverk