### PR TITLE
Klargjør tasks for automatisk brevutsending av brev om videre aktivitetsplikt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/iverksett/brev/aktivitetsplikt/OppdaterAktivitetspliktInnhentingOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/iverksett/brev/aktivitetsplikt/OppdaterAktivitetspliktInnhentingOppgaveTask.kt
@@ -56,8 +56,8 @@ class OppdaterAktivitetspliktInnhentingOppgaveTask(
 
     companion object {
         const val TYPE = "OppdaterAktivitetspliktInnhentingOppgaveTask"
-        const val FRIST_OPPFØLGINGSOPPGAVE = "2025-07-27"
-        const val FRIST_OPPRINNELIG_OPPGAVE = "2025-05-17"
+        const val FRIST_OPPFØLGINGSOPPGAVE = "2026-07-27"
+        const val FRIST_OPPRINNELIG_OPPGAVE = "2026-05-17"
 
         fun utledBeskrivelseForAktivitetspliktOppgave(oppgaveBeskrivelse: String?): String {
             val tidligereBeskrivelse = "\n${oppgaveBeskrivelse.orEmpty()}"

--- a/src/test/kotlin/no/nav/familie/ef/iverksett/brev/aktivitetsplikt/OppdaterAktivitetspliktInnhentingOppgaveTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/iverksett/brev/aktivitetsplikt/OppdaterAktivitetspliktInnhentingOppgaveTaskTest.kt
@@ -29,8 +29,8 @@ internal class OppdaterAktivitetspliktInnhentingOppgaveTaskTest {
     private val aktivitetspliktBrevRepository = mockk<AktivitetspliktBrevRepository>()
     private val oppgaveService = mockk<OppgaveService>()
 
-    private val initiellFristPåOppgave = "2025-05-17"
-    private val oppdatertFrist = "2025-07-27"
+    private val initiellFristPåOppgave = "2026-05-17"
+    private val oppdatertFrist = "2026-07-27"
 
     private val oppdaterOppgaveTask = OppdaterAktivitetspliktInnhentingOppgaveTask(aktivitetspliktBrevRepository, oppgaveService)
     private val oppgaveSlot = slot<Oppgave>()
@@ -141,7 +141,6 @@ internal class OppdaterAktivitetspliktInnhentingOppgaveTaskTest {
         assertThat(feil.message).contains("Oppgaven har blitt endret på underveis i flyten for innhenting av aktivitetsplikt.")
     }
 
-    /*
     @Test
     fun `skal huske å oppdatere gjeldende frist innen juni neste år`() {
         if (YearMonth.now().month >= Month.JUNE) {
@@ -149,7 +148,6 @@ internal class OppdaterAktivitetspliktInnhentingOppgaveTaskTest {
             assertThat(LocalDate.parse(OppdaterAktivitetspliktInnhentingOppgaveTask.FRIST_OPPFØLGINGSOPPGAVE).year).isEqualTo(YearMonth.now().year)
         }
     }
-     */
 
     @Nested
     inner class Beskrivelse {


### PR DESCRIPTION
Oppdaterer datoer til årets kjøring. Det er planlagt at brevutsendingen skal gjøres på mandag.

Tilhørende PR i ef-sak: https://github.com/navikt/familie-ef-sak/pull/3217

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-28916)