### PR TITLE
Juster ressurser etter Nais-anbefaling

### DIFF
--- a/.deploy/nais-preprod.yaml
+++ b/.deploy/nais-preprod.yaml
@@ -24,10 +24,10 @@ spec:
     max: 2
   resources:
     limits:
-      memory: 1024Mi
+      memory: 832Mi
     requests:
-      memory: 1024Mi
-      cpu: 50m
+      memory: 832Mi
+      cpu: 75m
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: dev

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -25,10 +25,10 @@ spec:
     max: 4
   resources:
     limits:
-      memory: 1024Mi
+      memory: 896Mi
     requests:
-      memory: 1024Mi
-      cpu: 100m
+      memory: 896Mi
+      cpu: 250m
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: prod


### PR DESCRIPTION
## Hva
Justerer CPU/memory requests og limits etter Nais console sine anbefalinger (basert på faktisk bruk). Forrige runde satte vi `memory request = limit`, men på de gamle høye verdiene, noe som ga over-reservering flagget som «dyrere ressurser enn forventet».

## Hvordan
- **Memory:** `request = limit` beholdt (Guaranteed QoS), satt til Nais sitt anbefalte limit avrundet til ren verdi.
- **CPU request** justert mot anbefaling. Ingen CPU-limit.