### PR TITLE
Fikse varierende test resultat under build

### DIFF
--- a/src/test/resources/application-servertest.yml
+++ b/src/test/resources/application-servertest.yml
@@ -40,6 +40,9 @@ arena-mq:
 unleash:
   enabled: false
 
+prosessering:
+  continuousRunning.enabled: false
+
 FAMILIE_OPPDRAG_API_URL: http://localhost:8087
 FAMILIE_INTEGRASJONER_API_URL: http://localhost:9085
 FAMILIE_TILBAKE_URL: http://localhost:8030


### PR DESCRIPTION
Task-worker'en kjørte i bakgrunnen under GrensesnittavstemmingControllerTest (arvet continuousRunning.enabled=true fra application.yml). Worker'en kunne plukke opp og fullføre en nyopprettet task mens testen fortsatt talte tasks, som ga en race condition og varierende testresultat.

Setter prosessering.continuousRunning.enabled=false i application-servertest.yml. Ingen andre tester er avhengige av at worker'en kjører automatisk.